### PR TITLE
Add editor mode to client

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ After installing the requirements, launch the program using one of the following
 python client.py
 ```
 
+To launch the map editor instead of the game, run:
+
+```bash
+python client.py --mode editor
+```
+
 A window will open containing a grid of tiles. Clicking on a tile moves the smiley‑face character to that location using pathfinding. Use the mouse wheel to zoom the camera in or out.
 
 ## License

--- a/client.py
+++ b/client.py
@@ -2,6 +2,7 @@ from panda3d.core import ModifierButtons, Vec3
 from direct.showbase.ShowBase import ShowBase
 from direct.interval.IntervalGlobal import Sequence, Func
 import math
+import argparse
 
 from Character import Character
 from DebugInfo import DebugInfo
@@ -14,7 +15,7 @@ from map_editor import MapEditor
 
 
 class Client(ShowBase):
-    """Application entry point that opens the window."""
+    """Application entry point that opens the game window."""
 
     def __init__(self, debug=False):
         super().__init__()
@@ -35,6 +36,8 @@ class Client(ShowBase):
         self.controls = Controls(self, self.camera_control, self.character)
         self.collision_control = CollisionControl(self.camera, self.render)
         self.editor = MapEditor(self, self.world)
+        self.editor.save_callback = self.save_map
+        self.editor.load_callback = self.load_map
 
         self.accept("mouse1", self.tile_click_event)
 
@@ -134,7 +137,34 @@ class Client(ShowBase):
 
         self.collision_control.cleanup()
 
+    # ------------------------------------------------------------------
+    # Editor helpers
+    # ------------------------------------------------------------------
+    def save_map(self, filename="map.json"):
+        """Save the current world grid to ``filename``."""
+        self.editor.save_map(filename)
+        print(f"Map saved to {filename}")
+
+    def load_map(self, filename="map.json"):
+        """Load a map from ``filename`` and rebuild the world."""
+        self.editor.load_map(filename)
+        print(f"Map loaded from {filename}")
+
 
 if __name__ == "__main__":
-    app = Client()
+    parser = argparse.ArgumentParser(description="RunePy client")
+    parser.add_argument(
+        "--mode",
+        choices=["game", "editor"],
+        default="game",
+        help="Start in regular game mode or map editor",
+    )
+    args = parser.parse_args()
+
+    if args.mode == "editor":
+        from editor_window import EditorWindow
+
+        app = EditorWindow()
+    else:
+        app = Client()
     app.run()

--- a/editor_window.py
+++ b/editor_window.py
@@ -1,0 +1,35 @@
+from direct.showbase.ShowBase import ShowBase
+from world import World
+from map_editor import MapEditor
+
+
+class EditorWindow(ShowBase):
+    """Standalone application providing a minimal tile editor."""
+
+    def __init__(self):
+        super().__init__()
+        self.disableMouse()
+
+        self.world = World(self.render)
+        self.editor = MapEditor(self, self.world)
+
+        self.accept("escape", self.userExit)
+        self.accept("s", self.save_map)
+        self.accept("l", self.load_map)
+
+        self.setBackgroundColor(0.5, 0.5, 0.5)
+        self.camera.setPos(0, 0, 10)
+        self.camera.lookAt(0, 0, 0)
+
+    def save_map(self):
+        self.editor.save_map("map.json")
+        print("Map saved to map.json")
+
+    def load_map(self):
+        self.editor.load_map("map.json")
+        print("Map loaded from map.json")
+
+
+if __name__ == "__main__":
+    app = EditorWindow()
+    app.run()

--- a/map_editor.py
+++ b/map_editor.py
@@ -6,6 +6,12 @@ class MapEditor:
         self.world = world
         client.accept("mouse3", self.toggle_tile)
 
+        # Convenience keybindings for saving/loading the map when running the
+        # editor as a standalone application. These will simply print an error
+        # if invoked when the client does not provide the corresponding methods.
+        client.accept("s", self._hotkey_save)
+        client.accept("l", self._hotkey_load)
+
     def toggle_tile(self):
         tile_x, tile_y = self.client.get_tile_from_mouse()
         if tile_x is None:
@@ -21,3 +27,59 @@ class MapEditor:
         if tile:
             color = (0.2, 0.2, 0.2, 1) if new_value == 0 else (1, 1, 1, 1)
             tile.setColor(color)
+
+    # ------------------------------------------------------------------
+    # Persistence helpers
+    # ------------------------------------------------------------------
+    def save_map(self, filename):
+        """Write the current grid to ``filename`` as JSON."""
+        import json
+
+        data = {
+            "radius": self.world.radius,
+            "tile_size": self.world.tile_size,
+            "grid": self.world.grid,
+        }
+        with open(filename, "w") as f:
+            json.dump(data, f)
+
+    def load_map(self, filename):
+        """Load ``filename`` and rebuild the world's tiles."""
+        import json
+
+        with open(filename, "r") as f:
+            data = json.load(f)
+
+        self.world.radius = data.get("radius", self.world.radius)
+        self.world.tile_size = data.get("tile_size", self.world.tile_size)
+        self.world.grid = data.get("grid", self.world.grid)
+
+        # Rebuild tiles from the loaded grid
+        self.world.tile_root.removeNode()
+        self.world.tile_root = self.world.render.attachNewNode("tile_root")
+        self.world.tiles = {}
+        self.world._generate_tiles()
+        self.world.tile_root.flattenStrong()
+
+    # ------------------------------------------------------------------
+    # Hotkeys used when running the editor standalone
+    # ------------------------------------------------------------------
+    def _hotkey_save(self):
+        if hasattr(self, "save_callback"):
+            self.save_callback()
+        else:
+            try:
+                self.save_map("map.json")
+                print("Map saved to map.json")
+            except Exception as exc:
+                print(f"Failed to save map: {exc}")
+
+    def _hotkey_load(self):
+        if hasattr(self, "load_callback"):
+            self.load_callback()
+        else:
+            try:
+                self.load_map("map.json")
+                print("Map loaded from map.json")
+            except Exception as exc:
+                print(f"Failed to load map: {exc}")

--- a/world.py
+++ b/world.py
@@ -7,7 +7,6 @@ from panda3d.core import (
     Point3,
     Vec3,
 )
-import random
 
 
 class World:
@@ -37,8 +36,9 @@ class World:
         for x in range(-self.radius, self.radius + 1):
             for y in range(-self.radius, self.radius + 1):
                 tile = self._create_tile((x * self.tile_size, y * self.tile_size, 0), self.tile_size)
-                random_color = (random.random(), random.random(), random.random(), 1)
-                tile.setColor(random_color)
+                grid_val = self.grid[y + self.radius][x + self.radius]
+                color = (1, 1, 1, 1) if grid_val else (0.2, 0.2, 0.2, 1)
+                tile.setColor(color)
                 tile.setName(f"tile_{x}_{y}")
                 self.tiles[(x, y)] = tile
 


### PR DESCRIPTION
## Summary
- add argparse to `client.py` for optional editor mode
- expose map saving/loading helpers in `Client`
- document how to launch the editor via command line

## Testing
- `python -m py_compile *.py editor_window.py`


------
https://chatgpt.com/codex/tasks/task_e_685346657890832e81ae710274135d22