### PR TITLE
Add editor mode to client

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ After installing the requirements, launch the program using one of the following
 python client.py
 ```
 
+To launch the map editor instead of the game, run:
+
+```bash
+python client.py --mode editor
+```
+
 A window will open containing a grid of tiles. Clicking on a tile moves the smiley‑face character to that location using pathfinding. Use the mouse wheel to zoom the camera in or out.
 
 ## License

--- a/client.py
+++ b/client.py
@@ -2,6 +2,7 @@ from panda3d.core import ModifierButtons, Vec3
 from direct.showbase.ShowBase import ShowBase
 from direct.interval.IntervalGlobal import Sequence, Func
 import math
+import argparse
 
 from Character import Character
 from DebugInfo import DebugInfo
@@ -14,7 +15,7 @@ from map_editor import MapEditor
 
 
 class Client(ShowBase):
-    """Application entry point that opens the window."""
+    """Application entry point that opens the game window."""
 
     def __init__(self, debug=False):
         super().__init__()
@@ -35,10 +36,12 @@ class Client(ShowBase):
         self.controls = Controls(self, self.camera_control, self.character)
         self.collision_control = CollisionControl(self.camera, self.render)
         self.editor = MapEditor(self, self.world)
+        self.editor.save_callback = self.save_map
+        self.editor.load_callback = self.load_map
 
         self.accept("mouse1", self.tile_click_event)
 
-        self.setBackgroundColor(0.5, 0.5, 0.5)
+        self.setBackgroundColor(0.9, 0.9, 0.9)
         self.camera.setPos(0, 0, 10)
         self.camera.lookAt(0, 0, 0)
 
@@ -99,7 +102,8 @@ class Client(ShowBase):
                 start_idx = (current_x + self.map_radius, current_y + self.map_radius)
                 end_idx = (snapped_x + self.map_radius, snapped_y + self.map_radius)
 
-                path = a_star(self.grid, start_idx, end_idx)
+                walkable_grid = [[1 if t.walkable else 0 for t in row] for row in self.grid]
+                path = a_star(walkable_grid, start_idx, end_idx)
                 self.log("Calculated Path:", path)
 
                 if path:
@@ -134,7 +138,34 @@ class Client(ShowBase):
 
         self.collision_control.cleanup()
 
+    # ------------------------------------------------------------------
+    # Editor helpers
+    # ------------------------------------------------------------------
+    def save_map(self, filename="map.json"):
+        """Save the current world grid to ``filename``."""
+        self.editor.save_map(filename)
+        print(f"Map saved to {filename}")
+
+    def load_map(self, filename="map.json"):
+        """Load a map from ``filename`` and rebuild the world."""
+        self.editor.load_map(filename)
+        print(f"Map loaded from {filename}")
+
 
 if __name__ == "__main__":
-    app = Client()
+    parser = argparse.ArgumentParser(description="RunePy client")
+    parser.add_argument(
+        "--mode",
+        choices=["game", "editor"],
+        default="game",
+        help="Start in regular game mode or map editor",
+    )
+    args = parser.parse_args()
+
+    if args.mode == "editor":
+        from editor_window import EditorWindow
+
+        app = EditorWindow()
+    else:
+        app = Client()
     app.run()

--- a/editor_window.py
+++ b/editor_window.py
@@ -1,0 +1,35 @@
+from direct.showbase.ShowBase import ShowBase
+from world import World
+from map_editor import MapEditor
+
+
+class EditorWindow(ShowBase):
+    """Standalone application providing a minimal tile editor."""
+
+    def __init__(self):
+        super().__init__()
+        self.disableMouse()
+
+        self.world = World(self.render)
+        self.editor = MapEditor(self, self.world)
+
+        self.accept("escape", self.userExit)
+        self.accept("s", self.save_map)
+        self.accept("l", self.load_map)
+
+        self.setBackgroundColor(0.9, 0.9, 0.9)
+        self.camera.setPos(0, 0, 10)
+        self.camera.lookAt(0, 0, 0)
+
+    def save_map(self):
+        self.editor.save_map("map.json")
+        print("Map saved to map.json")
+
+    def load_map(self):
+        self.editor.load_map("map.json")
+        print("Map loaded from map.json")
+
+
+if __name__ == "__main__":
+    app = EditorWindow()
+    app.run()

--- a/map_editor.py
+++ b/map_editor.py
@@ -5,6 +5,13 @@ class MapEditor:
         self.client = client
         self.world = world
         client.accept("mouse3", self.toggle_tile)
+        client.accept("i", self.toggle_interactable)
+
+        # Convenience keybindings for saving/loading the map when running the
+        # editor as a standalone application. These will simply print an error
+        # if invoked when the client does not provide the corresponding methods.
+        client.accept("s", self._hotkey_save)
+        client.accept("l", self._hotkey_load)
 
     def toggle_tile(self):
         tile_x, tile_y = self.client.get_tile_from_mouse()
@@ -14,10 +21,104 @@ class MapEditor:
         grid_y = tile_y + self.world.radius
         if not (0 <= grid_x < len(self.world.grid[0]) and 0 <= grid_y < len(self.world.grid)):
             return
-        current = self.world.grid[grid_y][grid_x]
-        new_value = 0 if current else 1
-        self.world.grid[grid_y][grid_x] = new_value
+        tile_data = self.world.grid[grid_y][grid_x]
+        tile_data.walkable = not tile_data.walkable
         tile = self.world.tiles.get((tile_x, tile_y))
         if tile:
-            color = (0.2, 0.2, 0.2, 1) if new_value == 0 else (1, 1, 1, 1)
-            tile.setColor(color)
+            tile.setColor(self.world._tile_color(tile_data))
+
+    def toggle_interactable(self):
+        tile_x, tile_y = self.client.get_tile_from_mouse()
+        if tile_x is None:
+            return
+        grid_x = tile_x + self.world.radius
+        grid_y = tile_y + self.world.radius
+        if not (0 <= grid_x < len(self.world.grid[0]) and 0 <= grid_y < len(self.world.grid)):
+            return
+        tile_data = self.world.grid[grid_y][grid_x]
+        if "interactable" in tile_data.tags:
+            tile_data.tags.remove("interactable")
+        else:
+            tile_data.tags.append("interactable")
+        print(f"Tile ({tile_x}, {tile_y}) interactable tags: {tile_data.tags}")
+
+    # ------------------------------------------------------------------
+    # Persistence helpers
+    # ------------------------------------------------------------------
+    def save_map(self, filename):
+        """Write the current grid to ``filename`` as JSON."""
+        import json
+
+        def serialize(tile):
+            return {
+                "walkable": tile.walkable,
+                "clickable": tile.clickable,
+                "description": tile.description,
+                "tags": tile.tags,
+            }
+
+        data = {
+            "radius": self.world.radius,
+            "tile_size": self.world.tile_size,
+            "grid": [[serialize(t) for t in row] for row in self.world.grid],
+        }
+        with open(filename, "w") as f:
+            json.dump(data, f)
+
+    def load_map(self, filename):
+        """Load ``filename`` and rebuild the world's tiles."""
+        import json
+
+        with open(filename, "r") as f:
+            data = json.load(f)
+
+        self.world.radius = data.get("radius", self.world.radius)
+        self.world.tile_size = data.get("tile_size", self.world.tile_size)
+
+        def deserialize(d):
+            from world import TileData
+
+            return TileData(
+                walkable=d.get("walkable", True),
+                clickable=d.get("clickable", True),
+                description=d.get("description", ""),
+                tags=d.get("tags", []),
+            )
+
+        loaded_grid = data.get("grid", [])
+        if loaded_grid:
+            self.world.grid = [[deserialize(t) for t in row] for row in loaded_grid]
+
+        # Rebuild tiles from the loaded grid
+        self.world.tile_root.removeNode()
+        self.world.grid_lines.removeNode()
+        self.world.tile_root = self.world.render.attachNewNode("tile_root")
+        self.world.grid_lines = self.world.render.attachNewNode("grid_lines")
+        self.world.tiles = {}
+        self.world._generate_tiles()
+        self.world._create_grid_lines()
+        self.world.tile_root.flattenStrong()
+        self.world.grid_lines.flattenStrong()
+
+    # ------------------------------------------------------------------
+    # Hotkeys used when running the editor standalone
+    # ------------------------------------------------------------------
+    def _hotkey_save(self):
+        if hasattr(self, "save_callback"):
+            self.save_callback()
+        else:
+            try:
+                self.save_map("map.json")
+                print("Map saved to map.json")
+            except Exception as exc:
+                print(f"Failed to save map: {exc}")
+
+    def _hotkey_load(self):
+        if hasattr(self, "load_callback"):
+            self.load_callback()
+        else:
+            try:
+                self.load_map("map.json")
+                print("Map loaded from map.json")
+            except Exception as exc:
+                print(f"Failed to load map: {exc}")

--- a/world.py
+++ b/world.py
@@ -1,3 +1,16 @@
+from dataclasses import dataclass, field
+from typing import List
+
+
+@dataclass
+class TileData:
+    """Metadata describing a single map tile."""
+
+    walkable: bool = True
+    clickable: bool = True
+    description: str = ""
+    tags: List[str] = field(default_factory=list)
+
 from panda3d.core import (
     BitMask32,
     CardMaker,
@@ -6,8 +19,8 @@ from panda3d.core import (
     Plane,
     Point3,
     Vec3,
+    LineSegs,
 )
-import random
 
 
 class World:
@@ -20,25 +33,34 @@ class World:
         self.debug = debug
 
         width = height = radius * 2 + 1
-        self.grid = [[1 for _ in range(width)] for _ in range(height)]
+        self.grid = [[TileData() for _ in range(width)] for _ in range(height)]
 
         self.tile_root = self.render.attachNewNode("tile_root")
         self.tiles = {}
+        self.grid_lines = self.render.attachNewNode("grid_lines")
 
         self._generate_tiles()
+        self._create_grid_lines()
         self.tile_root.flattenStrong()
+        self.grid_lines.flattenStrong()
         self._create_collision_plane()
 
     def log(self, *args, **kwargs):
         if self.debug:
             print(*args, **kwargs)
 
+    def _tile_color(self, tile: TileData):
+        """Return the display color for a tile based on its state."""
+        if tile.walkable:
+            return (0.3, 0.3, 0.3, 1)
+        return (0.1, 0.1, 0.1, 1)
+
     def _generate_tiles(self):
         for x in range(-self.radius, self.radius + 1):
             for y in range(-self.radius, self.radius + 1):
                 tile = self._create_tile((x * self.tile_size, y * self.tile_size, 0), self.tile_size)
-                random_color = (random.random(), random.random(), random.random(), 1)
-                tile.setColor(random_color)
+                tile_data = self.grid[y + self.radius][x + self.radius]
+                tile.setColor(self._tile_color(tile_data))
                 tile.setName(f"tile_{x}_{y}")
                 self.tiles[(x, y)] = tile
 
@@ -49,6 +71,29 @@ class World:
         tile.setPos(*position)
         tile.setHpr(0, -90, 0)
         return tile
+
+    def _create_grid_lines(self):
+        lines = LineSegs()
+        lines.setThickness(1.0)
+        lines.setColor(0.2, 0.2, 0.2, 1)
+
+        start = -self.radius - 0.5
+        end = self.radius + 0.5
+
+        for i in range(self.radius * 2 + 2):
+            pos = start + i
+            x = pos * self.tile_size
+            lines.moveTo(x, start * self.tile_size, 0.02)
+            lines.drawTo(x, end * self.tile_size, 0.02)
+
+        for i in range(self.radius * 2 + 2):
+            pos = start + i
+            y = pos * self.tile_size
+            lines.moveTo(start * self.tile_size, y, 0.02)
+            lines.drawTo(end * self.tile_size, y, 0.02)
+
+        node = lines.create()
+        self.grid_lines.attachNewNode(node)
 
     def _create_collision_plane(self):
         plane = CollisionPlane(Plane(Vec3(0, 0, 1), Point3(0, 0, 0)))


### PR DESCRIPTION
## Summary
- add argparse to `client.py` for optional editor mode
- expose map saving/loading helpers in `Client`
- document how to launch the editor via command line
- add tile metadata, grid lines, and new color scheme
- allow toggling interactable tag in the map editor

## Testing
- `python -m py_compile *.py editor_window.py`


------
https://chatgpt.com/codex/tasks/task_e_685346657890832e81ae710274135d22