### PR TITLE
Update keybinding defaults and menu logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,9 @@ python client.py --mode editor
 
 A window will open containing a grid of tiles. Clicking on a tile moves the smiley‑face character to that location using pathfinding. Use the mouse wheel to zoom the camera in or out.
 
-Press ``Esc`` in either mode to open an options menu where you can rebind any of the controls, including the editor's WASD movement and save/load shortcuts.
+Zooming is always handled by the mouse wheel and cannot be changed. In the editor the camera's forward/back movement is fixed to ``W`` and ``S`` while the ``A`` and ``D`` keys remain rebindable.
+
+Press ``Esc`` in either mode to open an options menu where you can rebind the available controls, including the editor's side movement and save/load shortcuts. When this menu is visible, gameplay clicks are ignored so you can't interact with the world through the menu.
 
 ## License
 

--- a/client.py
+++ b/client.py
@@ -71,6 +71,8 @@ class Client(ShowBase):
         return task.cont
 
     def tile_click_event(self):
+        if self.options_menu.visible:
+            return
         self.log("Tile clicked!")
         if self.mouseWatcherNode.hasMouse():
             mpos = self.mouseWatcherNode.getMouse()

--- a/editor_window.py
+++ b/editor_window.py
@@ -27,8 +27,6 @@ class EditorWindow(ShowBase):
             "load_map": "control-l",
             "toggle_tile": "mouse3",
             "toggle_interactable": "i",
-            "move_forward": "w",
-            "move_back": "s",
             "move_left": "a",
             "move_right": "d",
         }
@@ -37,18 +35,18 @@ class EditorWindow(ShowBase):
 
         self.key_manager.bind("open_menu", self.options_menu.toggle)
         self.editor.register_bindings(self.key_manager)
-        self.key_manager.bind("move_forward",
-                              lambda: self.camera_control.set_move("forward", True),
-                              lambda: self.camera_control.set_move("forward", False))
-        self.key_manager.bind("move_back",
-                              lambda: self.camera_control.set_move("back", True),
-                              lambda: self.camera_control.set_move("back", False))
         self.key_manager.bind("move_left",
                               lambda: self.camera_control.set_move("left", True),
                               lambda: self.camera_control.set_move("left", False))
         self.key_manager.bind("move_right",
                               lambda: self.camera_control.set_move("right", True),
                               lambda: self.camera_control.set_move("right", False))
+
+        # Bind forward/back movement directly so W/S are fixed keys
+        self.accept("w", lambda: self.camera_control.set_move("forward", True))
+        self.accept("w-up", lambda: self.camera_control.set_move("forward", False))
+        self.accept("s", lambda: self.camera_control.set_move("back", True))
+        self.accept("s-up", lambda: self.camera_control.set_move("back", False))
 
         self.setBackgroundColor(0.9, 0.9, 0.9)
 


### PR DESCRIPTION
## Summary
- remove W/S from configurable controls and bind directly
- ignore mouse clicks when the escape menu is open
- document fixed wheel zoom and fixed forward/back keys

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6853534cfd30832ea3e57077630d96de