### PR TITLE
Limit camera zoom out height

### DIFF
--- a/Controls.py
+++ b/Controls.py
@@ -17,7 +17,7 @@ class Controls(DirectObject):
         # self.base.taskMgr.add(self.middle_mouse_drag_event, 'middleMouseTask')
 
     def zoom(self, direction):
-        """Zoom the camera while clamping the minimum height."""
+        """Zoom the camera while clamping the minimum and maximum height."""
         zoom_speed = 10
         cam_vec = self.base.render.getRelativeVector(
             self.camera_control.camera, Vec3(0, 1, 0)
@@ -27,10 +27,13 @@ class Controls(DirectObject):
         current_world_pos = self.camera_control.camera.getPos(self.base.render)
         new_world_pos = current_world_pos - cam_vec * direction * zoom_speed
 
-        # Prevent the camera from moving below the map plane
+        # Prevent the camera from moving below or far above the map plane
         min_z = 5.0
+        max_z = 80.0
         if new_world_pos.getZ() < min_z:
             new_world_pos.setZ(min_z)
+        elif new_world_pos.getZ() > max_z:
+            new_world_pos.setZ(max_z)
 
         # Convert back to the camera's parent space before applying
         parent = self.camera_control.camera.getParent()


### PR DESCRIPTION
## Summary
- cap max zoom height at 80 units

## Testing
- `python -m py_compile Camera.py Character.py client.py world.py map_editor.py options_menu.py editor_window.py DebugInfo.py collision.py pathfinding.py Controls.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68537d4f5618832e98357be423f47f3a