### PR TITLE
Refactor mouse tile helpers

### DIFF
--- a/client.py
+++ b/client.py
@@ -1,4 +1,5 @@
 from panda3d.core import ModifierButtons, Vec3
+from utils import get_mouse_tile_coords, get_tile_from_mouse
 from direct.showbase.ShowBase import ShowBase
 from direct.interval.IntervalGlobal import Sequence, Func
 import math
@@ -52,20 +53,8 @@ class Client(ShowBase):
         if self.debug:
             print(*args, **kwargs)
 
-    def get_mouse_tile_coords(self):
-        if self.mouseWatcherNode.hasMouse():
-            mpos = self.mouseWatcherNode.getMouse()
-            tile_x = round(mpos.getX() * 10)
-            tile_y = round(mpos.getY() * 10)
-            return mpos, tile_x, tile_y
-        return None, None, None
-
-    def get_tile_from_mouse(self):
-        _, tile_x, tile_y = self.get_mouse_tile_coords()
-        return tile_x, tile_y
-
     def update_tile_hover(self, task):
-        mpos, tile_x, tile_y = self.get_mouse_tile_coords()
+        mpos, tile_x, tile_y = get_mouse_tile_coords(self.mouseWatcherNode)
         if mpos:
             self.debug_info.update_tile_info(mpos, tile_x, tile_y)
         return task.cont
@@ -76,7 +65,9 @@ class Client(ShowBase):
         self.log("Tile clicked!")
         if self.mouseWatcherNode.hasMouse():
             mpos = self.mouseWatcherNode.getMouse()
+            tile_x, tile_y = get_tile_from_mouse(self.mouseWatcherNode)
             self.log(f"Mouse position detected: {mpos}")
+            self.log(f"Clicked tile coords: {(tile_x, tile_y)}")
         else:
             self.log("No mouse detected.")
             return

--- a/editor_window.py
+++ b/editor_window.py
@@ -4,6 +4,7 @@ from map_editor import MapEditor
 from Camera import FreeCameraControl
 from options_menu import KeyBindingManager, OptionsMenu
 from Controls import Controls
+from utils import get_mouse_tile_coords, get_tile_from_mouse
 
 
 
@@ -54,20 +55,6 @@ class EditorWindow(ShowBase):
 
         self.camera.setPos(0, 0, 10)
         self.camera.lookAt(0, 0, 0)
-
-    def get_mouse_tile_coords(self):
-        """Return the mouse position and snapped tile coordinates."""
-        if self.mouseWatcherNode.hasMouse():
-            mpos = self.mouseWatcherNode.getMouse()
-            tile_x = round(mpos.getX() * 10)
-            tile_y = round(mpos.getY() * 10)
-            return mpos, tile_x, tile_y
-        return None, None, None
-
-    def get_tile_from_mouse(self):
-        """Return just the tile coordinates from the mouse position."""
-        _, tile_x, tile_y = self.get_mouse_tile_coords()
-        return tile_x, tile_y
 
     def save_map(self):
         self.editor.save_map("map.json")

--- a/map_editor.py
+++ b/map_editor.py
@@ -1,3 +1,6 @@
+from utils import get_tile_from_mouse
+
+
 class MapEditor:
     """Basic tile editing functionality."""
 
@@ -16,7 +19,7 @@ class MapEditor:
     def toggle_tile(self):
         if self.client.options_menu.visible:
             return
-        tile_x, tile_y = self.client.get_tile_from_mouse()
+        tile_x, tile_y = get_tile_from_mouse(self.client.mouseWatcherNode)
         if tile_x is None:
             return
         grid_x = tile_x + self.world.radius
@@ -32,7 +35,7 @@ class MapEditor:
     def toggle_interactable(self):
         if self.client.options_menu.visible:
             return
-        tile_x, tile_y = self.client.get_tile_from_mouse()
+        tile_x, tile_y = get_tile_from_mouse(self.client.mouseWatcherNode)
         if tile_x is None:
             return
         grid_x = tile_x + self.world.radius

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,18 @@
+# Utility functions shared across modules
+from panda3d.core import MouseWatcher
+
+
+def get_mouse_tile_coords(mouse_watcher: "MouseWatcher"):
+    """Return the mouse position and snapped tile coordinates."""
+    if mouse_watcher and mouse_watcher.hasMouse():
+        mpos = mouse_watcher.getMouse()
+        tile_x = round(mpos.getX() * 10)
+        tile_y = round(mpos.getY() * 10)
+        return mpos, tile_x, tile_y
+    return None, None, None
+
+
+def get_tile_from_mouse(mouse_watcher: "MouseWatcher"):
+    """Return just the tile coordinates from the mouse position."""
+    _, tile_x, tile_y = get_mouse_tile_coords(mouse_watcher)
+    return tile_x, tile_y


### PR DESCRIPTION
## Summary
- factor out mouse coordinate helpers to utils module
- call new helpers from client and map editor
- drop duplicate helper methods from Client and EditorWindow classes

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685396024280832eb37ec5d0a7cdda8f