### PR TITLE
Add configurable key bindings via config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ Zooming is always handled by the mouse wheel and cannot be changed. In the edito
 
 Press ``Esc`` in either mode to open an options menu where you can rebind the available controls, including the editor's side movement and save/load shortcuts. When this menu is visible, gameplay clicks are ignored so you can't interact with the world through the menu.
 
+## Configuration
+
+Default key bindings are defined in ``config.json`` at the repository root. Edit this file to customize the controls that are initially loaded by both the game and the editor.
+
 ## License
 
 This project is licensed under the MIT License. See [LICENSE](LICENSE) for details.

--- a/client.py
+++ b/client.py
@@ -13,6 +13,7 @@ from world import World
 from pathfinding import a_star
 from collision import CollisionControl
 from options_menu import KeyBindingManager, OptionsMenu
+from config import load_key_bindings
 
 
 class Client(ShowBase):
@@ -36,7 +37,8 @@ class Client(ShowBase):
         self.camera_control = CameraControl(self.camera, self.render, self.character)
         self.controls = Controls(self, self.camera_control, self.character)
         self.collision_control = CollisionControl(self.camera, self.render)
-        self.key_manager = KeyBindingManager(self, {"open_menu": "escape"})
+        bindings = load_key_bindings()
+        self.key_manager = KeyBindingManager(self, bindings if bindings else {"open_menu": "escape"})
         self.options_menu = OptionsMenu(self, self.key_manager)
         self.key_manager.bind("open_menu", self.options_menu.toggle)
 

--- a/config.json
+++ b/config.json
@@ -1,0 +1,11 @@
+{
+  "key_bindings": {
+    "open_menu": "escape",
+    "save_map": "control-s",
+    "load_map": "control-l",
+    "toggle_tile": "mouse3",
+    "toggle_interactable": "i",
+    "move_left": "a",
+    "move_right": "d"
+  }
+}

--- a/config.py
+++ b/config.py
@@ -1,0 +1,24 @@
+import json
+import os
+
+DEFAULT_CONFIG_PATH = os.path.join(os.path.dirname(__file__), "config.json")
+
+
+def load_config(path: str = DEFAULT_CONFIG_PATH) -> dict:
+    """Load the configuration file if it exists."""
+    if not os.path.exists(path):
+        return {}
+    with open(path, "r") as f:
+        try:
+            return json.load(f)
+        except json.JSONDecodeError:
+            return {}
+
+
+def load_key_bindings(path: str = DEFAULT_CONFIG_PATH) -> dict:
+    """Return the ``key_bindings`` section of the config file."""
+    config = load_config(path)
+    bindings = config.get("key_bindings", {})
+    if isinstance(bindings, dict):
+        return bindings
+    return {}

--- a/editor_window.py
+++ b/editor_window.py
@@ -3,6 +3,7 @@ from world import World
 from map_editor import MapEditor
 from Camera import FreeCameraControl
 from options_menu import KeyBindingManager, OptionsMenu
+from config import load_key_bindings
 from Controls import Controls
 from utils import get_mouse_tile_coords, get_tile_from_mouse
 
@@ -24,15 +25,7 @@ class EditorWindow(ShowBase):
         self.camera_control.start(self)
         self.controls = Controls(self, self.camera_control, None)
 
-        default_keys = {
-            "open_menu": "escape",
-            "save_map": "control-s",
-            "load_map": "control-l",
-            "toggle_tile": "mouse3",
-            "toggle_interactable": "i",
-            "move_left": "a",
-            "move_right": "d",
-        }
+        default_keys = load_key_bindings()
         self.key_manager = KeyBindingManager(self, default_keys)
         self.options_menu = OptionsMenu(self, self.key_manager)
 


### PR DESCRIPTION
## Summary
- add `config.json` with default key bindings
- provide `config.py` loader utilities
- load bindings from config in `client.py` and `editor_window.py`
- mention configuration file in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853a0ed2c88832eaaca2a7c67d745ba