### PR TITLE
Enhance tile metadata system

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ RunePy is a small demonstration project built with [Panda3D](https://www.panda3d
 - Simple collision and ray casting
 - Camera zoom limits keep the view between a minimum and maximum height
 - Built-in map editor with hotkeys for saving and loading maps
+- Tiles support custom metadata loaded from map files
 
 ## Repository Layout
 

--- a/runepy/client.py
+++ b/runepy/client.py
@@ -143,6 +143,9 @@ class Client(ShowBase):
     def load_map(self, filename="map.json"):
         """Load a map from ``filename`` and rebuild the world."""
         self.editor.load_map(filename)
+        # Update cached references since the world may have changed size
+        self.grid = self.world.grid
+        self.map_radius = self.world.radius
         print(f"Map loaded from {filename}")
 
 

--- a/runepy/map_editor.py
+++ b/runepy/map_editor.py
@@ -54,58 +54,11 @@ class MapEditor:
     # ------------------------------------------------------------------
     def save_map(self, filename):
         """Write the current grid to ``filename`` as JSON."""
-        import json
-
-        def serialize(tile):
-            return {
-                "walkable": tile.walkable,
-                "clickable": tile.clickable,
-                "description": tile.description,
-                "tags": tile.tags,
-            }
-
-        data = {
-            "radius": self.world.radius,
-            "tile_size": self.world.tile_size,
-            "grid": [[serialize(t) for t in row] for row in self.world.grid],
-        }
-        with open(filename, "w") as f:
-            json.dump(data, f)
+        self.world.save_map(filename)
 
     def load_map(self, filename):
         """Load ``filename`` and rebuild the world's tiles."""
-        import json
-
-        with open(filename, "r") as f:
-            data = json.load(f)
-
-        self.world.radius = data.get("radius", self.world.radius)
-        self.world.tile_size = data.get("tile_size", self.world.tile_size)
-
-        def deserialize(d):
-            from runepy.world import TileData
-
-            return TileData(
-                walkable=d.get("walkable", True),
-                clickable=d.get("clickable", True),
-                description=d.get("description", ""),
-                tags=d.get("tags", []),
-            )
-
-        loaded_grid = data.get("grid", [])
-        if loaded_grid:
-            self.world.grid = [[deserialize(t) for t in row] for row in loaded_grid]
-
-        # Rebuild tiles from the loaded grid
-        self.world.tile_root.removeNode()
-        self.world.grid_lines.removeNode()
-        self.world.tile_root = self.world.render.attachNewNode("tile_root")
-        self.world.grid_lines = self.world.render.attachNewNode("grid_lines")
-        self.world.tiles = {}
-        self.world._generate_tiles()
-        self.world._create_grid_lines()
-        self.world.tile_root.flattenStrong()
-        self.world.grid_lines.flattenStrong()
+        self.world.load_map(filename)
 
     # ------------------------------------------------------------------
     # Hotkeys used when running the editor standalone

--- a/tests/test_tiledata.py
+++ b/tests/test_tiledata.py
@@ -1,0 +1,11 @@
+from runepy.world import TileData
+
+def test_tiledata_round_trip_custom_props():
+    tile = TileData(walkable=False, description="foo", properties={"cost": 5})
+    data = tile.to_dict()
+    assert data["cost"] == 5
+    loaded = TileData.from_dict(data)
+    assert loaded.properties["cost"] == 5
+    assert not loaded.walkable
+    assert loaded.description == "foo"
+


### PR DESCRIPTION
## Summary
- allow `TileData` to store arbitrary properties
- provide `TileData.to_dict` and `from_dict` helpers
- load maps during `World` construction and add `save_map`/`load_map`
- use world persistence helpers from map editor and client
- document custom metadata in README
- test round‑trip behaviour for custom properties

## Testing
- `pip install panda3d -q`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853b1c2772c832ebe3b27533aa118e9