### PR TITLE
Implement universal tile hover highlight

### DIFF
--- a/runepy/client.py
+++ b/runepy/client.py
@@ -57,6 +57,12 @@ class Client(ShowBase):
         mpos, tile_x, tile_y = get_mouse_tile_coords(self.mouseWatcherNode)
         if mpos:
             self.debug_info.update_tile_info(mpos, tile_x, tile_y)
+            if (tile_x, tile_y) in self.world.tiles:
+                self.world.highlight_tile(tile_x, tile_y)
+            else:
+                self.world.clear_highlight()
+        else:
+            self.world.clear_highlight()
         return task.cont
 
     def tile_click_event(self):

--- a/runepy/editor_window.py
+++ b/runepy/editor_window.py
@@ -56,6 +56,19 @@ class EditorWindow(ShowBase):
         self.camera.setPos(0, 0, 10)
         self.camera.lookAt(0, 0, 0)
 
+        self.taskMgr.add(self.update_tile_hover, "updateTileHoverTask")
+
+    def update_tile_hover(self, task):
+        mpos, tile_x, tile_y = get_mouse_tile_coords(self.mouseWatcherNode)
+        if mpos:
+            if (tile_x, tile_y) in self.world.tiles:
+                self.world.highlight_tile(tile_x, tile_y)
+            else:
+                self.world.clear_highlight()
+        else:
+            self.world.clear_highlight()
+        return task.cont
+
     def save_map(self):
         self.editor.save_map("map.json")
         print("Map saved to map.json")

--- a/runepy/world.py
+++ b/runepy/world.py
@@ -80,6 +80,8 @@ class World:
         self.tile_root.flattenStrong()
         self.grid_lines.flattenStrong()
 
+        self._hovered = None
+
     def save_map(self, filename):
         """Write the current grid to ``filename`` as JSON."""
         import json
@@ -142,6 +144,25 @@ class World:
 
         node = lines.create()
         self.grid_lines.attachNewNode(node)
+
+    def highlight_tile(self, x: int, y: int, scale: float = 0.8):
+        """Darken the tile at ``(x, y)`` to indicate a hover state."""
+        coord = (x, y)
+        if self._hovered == coord:
+            return
+        if self._hovered in self.tiles:
+            self.tiles[self._hovered].clearColorScale()
+            self._hovered = None
+        tile = self.tiles.get(coord)
+        if tile:
+            tile.setColorScale(scale, scale, scale, 1)
+            self._hovered = coord
+
+    def clear_highlight(self):
+        """Remove any hover highlight from the map."""
+        if self._hovered in self.tiles:
+            self.tiles[self._hovered].clearColorScale()
+        self._hovered = None
 
     def _create_collision_plane(self):
         plane = CollisionPlane(Plane(Vec3(0, 0, 1), Point3(0, 0, 0)))


### PR DESCRIPTION
## Summary
- darken hovered tiles using `World.highlight_tile`
- update `Client` and map editor to call the new highlight logic each frame

## Testing
- `pip install -q panda3d==1.10.15`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853b4f962b0832ebf4f76c786161fad