### PR TITLE
Implement universal tile hover highlight

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ RunePy is a small demonstration project built with [Panda3D](https://www.panda3d
 - Camera zoom limits keep the view between a minimum and maximum height
 - Built-in map editor with hotkeys for saving and loading maps
 - Tiles support custom metadata loaded from map files
+- Individual tiles darken slightly when hovered to show the current mouse
+  position
 
 ## Repository Layout
 

--- a/runepy/client.py
+++ b/runepy/client.py
@@ -57,6 +57,12 @@ class Client(ShowBase):
         mpos, tile_x, tile_y = get_mouse_tile_coords(self.mouseWatcherNode)
         if mpos:
             self.debug_info.update_tile_info(mpos, tile_x, tile_y)
+            if (tile_x, tile_y) in self.world.tiles:
+                self.world.highlight_tile(tile_x, tile_y)
+            else:
+                self.world.clear_highlight()
+        else:
+            self.world.clear_highlight()
         return task.cont
 
     def tile_click_event(self):

--- a/runepy/editor_window.py
+++ b/runepy/editor_window.py
@@ -56,6 +56,19 @@ class EditorWindow(ShowBase):
         self.camera.setPos(0, 0, 10)
         self.camera.lookAt(0, 0, 0)
 
+        self.taskMgr.add(self.update_tile_hover, "updateTileHoverTask")
+
+    def update_tile_hover(self, task):
+        mpos, tile_x, tile_y = get_mouse_tile_coords(self.mouseWatcherNode)
+        if mpos:
+            if (tile_x, tile_y) in self.world.tiles:
+                self.world.highlight_tile(tile_x, tile_y)
+            else:
+                self.world.clear_highlight()
+        else:
+            self.world.clear_highlight()
+        return task.cont
+
     def save_map(self):
         self.editor.save_map("map.json")
         print("Map saved to map.json")

--- a/runepy/world.py
+++ b/runepy/world.py
@@ -77,8 +77,12 @@ class World:
 
         self._generate_tiles()
         self._create_grid_lines()
-        self.tile_root.flattenStrong()
+        # Flattening tiles would merge them into a single node which prevents
+        # per-tile color adjustments. Keep tiles separate so each can be
+        # highlighted individually. Grid lines remain flattened for performance.
         self.grid_lines.flattenStrong()
+
+        self._hovered = None
 
     def save_map(self, filename):
         """Write the current grid to ``filename`` as JSON."""
@@ -143,6 +147,25 @@ class World:
         node = lines.create()
         self.grid_lines.attachNewNode(node)
 
+    def highlight_tile(self, x: int, y: int, scale: float = 0.8):
+        """Darken the tile at ``(x, y)`` to indicate a hover state."""
+        coord = (x, y)
+        if self._hovered == coord:
+            return
+        if self._hovered in self.tiles:
+            self.tiles[self._hovered].clearColorScale()
+            self._hovered = None
+        tile = self.tiles.get(coord)
+        if tile:
+            tile.setColorScale(scale, scale, scale, 1)
+            self._hovered = coord
+
+    def clear_highlight(self):
+        """Remove any hover highlight from the map."""
+        if self._hovered in self.tiles:
+            self.tiles[self._hovered].clearColorScale()
+        self._hovered = None
+
     def _create_collision_plane(self):
         plane = CollisionPlane(Plane(Vec3(0, 0, 1), Point3(0, 0, 0)))
         c_node = CollisionNode("grid_plane")
@@ -178,7 +201,8 @@ class World:
         self.tiles = {}
         self._generate_tiles()
         self._create_grid_lines()
-        self.tile_root.flattenStrong()
+        # Keep tiles un-flattened so hover highlighting works on individual
+        # nodes. Grid lines can still be flattened for efficiency.
         self.grid_lines.flattenStrong()
 
 


### PR DESCRIPTION
## Summary
- darken hovered tiles using `World.highlight_tile`
- update `Client` and map editor to call the new highlight logic each frame
- preserve individual tile nodes to allow highlighting
- document tile hover in README

## Testing
- `pip install -q panda3d==1.10.15`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6853b4f962b0832ebf4f76c786161fad