### PR TITLE
Refactor init with BaseApp

### DIFF
--- a/runepy/__init__.py
+++ b/runepy/__init__.py
@@ -1,6 +1,7 @@
 """RunePy package."""
 
 from . import pathfinding
+from .base_app import BaseApp
 
-__all__ = ["pathfinding"]
+__all__ = ["pathfinding", "BaseApp"]
 

--- a/runepy/base_app.py
+++ b/runepy/base_app.py
@@ -1,0 +1,29 @@
+from direct.showbase.ShowBase import ShowBase
+from runepy.loading_screen import LoadingScreen
+
+
+class BaseApp(ShowBase):
+    """Application base that shows a loading screen and defers setup."""
+
+    def __init__(self):
+        super().__init__()
+        self.loading_screen = LoadingScreen(self)
+        self.loading_screen.update(0, "Initializing")
+        self.taskMgr.doMethodLater(0, self._init_app, "initApp")
+
+    def _init_app(self, task):
+        self.disableMouse()
+        self.initialize()
+        self.loading_screen.update(100, "Done")
+        self.taskMgr.doMethodLater(1.0, self._remove_loading_screen, "hideLoading")
+        return task.done
+
+    def initialize(self):
+        """Subclasses should override this to perform their setup."""
+        raise NotImplementedError
+
+    def _remove_loading_screen(self, task):
+        if hasattr(self, "loading_screen") and self.loading_screen:
+            self.loading_screen.destroy()
+            self.loading_screen = None
+        return task.done

--- a/runepy/client.py
+++ b/runepy/client.py
@@ -1,9 +1,10 @@
 from panda3d.core import ModifierButtons, Vec3
 from runepy.utils import get_mouse_tile_coords, get_tile_from_mouse
-from direct.showbase.ShowBase import ShowBase
 from direct.interval.IntervalGlobal import Sequence, Func
 import math
 import argparse
+
+from runepy.base_app import BaseApp
 
 from runepy.character import Character
 from runepy.debuginfo import DebugInfo
@@ -16,21 +17,15 @@ from runepy.options_menu import KeyBindingManager, OptionsMenu
 from runepy.loading_screen import LoadingScreen
 
 
-class Client(ShowBase):
+class Client(BaseApp):
     """Application entry point that opens the game window."""
 
     def __init__(self, debug=False):
-        super().__init__()
         self.debug = debug
-        # Show a loading screen immediately then perform heavy setup
-        self.loading_screen = LoadingScreen(self)
-        self.loading_screen.update(0, "Initializing")
-        # Defer the rest of initialization so the loading screen can render first
-        self.taskMgr.doMethodLater(0, self._init_game, "initGame")
+        super().__init__()
 
-    def _init_game(self, task):
-        """Heavy initialization broken out so the loading screen appears first."""
-        self.disableMouse()
+    def initialize(self):
+        """Perform heavy initialization for the game mode."""
         self.debug_info = DebugInfo()
 
         self.mouseWatcherNode.set_modifier_buttons(ModifierButtons())
@@ -60,9 +55,6 @@ class Client(ShowBase):
         self.camera.lookAt(0, 0, 0)
 
         self.taskMgr.add(self.update_tile_hover, "updateTileHoverTask")
-        self.loading_screen.update(100, "Done")
-        self.taskMgr.doMethodLater(1.0, self._remove_loading_screen, "hideLoading")
-        return task.done
 
     def log(self, *args, **kwargs):
         if self.debug:
@@ -82,11 +74,6 @@ class Client(ShowBase):
             self.world.clear_highlight()
         return task.cont
 
-    def _remove_loading_screen(self, task):
-        if hasattr(self, "loading_screen") and self.loading_screen:
-            self.loading_screen.destroy()
-            self.loading_screen = None
-        return task.done
 
     def tile_click_event(self):
         if self.options_menu.visible:

--- a/runepy/editor_window.py
+++ b/runepy/editor_window.py
@@ -1,4 +1,4 @@
-from direct.showbase.ShowBase import ShowBase
+from runepy.base_app import BaseApp
 from runepy.world import World
 from runepy.map_editor import MapEditor
 from runepy.camera import FreeCameraControl
@@ -8,13 +8,13 @@ from runepy.utils import get_mouse_tile_coords, get_tile_from_mouse
 
 
 
-class EditorWindow(ShowBase):
+class EditorWindow(BaseApp):
     """Standalone application providing a minimal tile editor."""
 
     def __init__(self):
         super().__init__()
-        self.disableMouse()
 
+    def initialize(self):
         self.world = World(self.render)
         self.editor = MapEditor(self, self.world)
         self.editor.save_callback = self.save_map
@@ -38,12 +38,16 @@ class EditorWindow(ShowBase):
 
         self.key_manager.bind("open_menu", self.options_menu.toggle)
         self.editor.register_bindings(self.key_manager)
-        self.key_manager.bind("move_left",
-                              lambda: self.camera_control.set_move("left", True),
-                              lambda: self.camera_control.set_move("left", False))
-        self.key_manager.bind("move_right",
-                              lambda: self.camera_control.set_move("right", True),
-                              lambda: self.camera_control.set_move("right", False))
+        self.key_manager.bind(
+            "move_left",
+            lambda: self.camera_control.set_move("left", True),
+            lambda: self.camera_control.set_move("left", False),
+        )
+        self.key_manager.bind(
+            "move_right",
+            lambda: self.camera_control.set_move("right", True),
+            lambda: self.camera_control.set_move("right", False),
+        )
 
         # Bind forward/back movement directly so W/S are fixed keys
         self.accept("w", lambda: self.camera_control.set_move("forward", True))


### PR DESCRIPTION
## Summary
- add `BaseApp` to handle loading screen and deferred setup
- migrate `Client` and `EditorWindow` to subclass `BaseApp`
- expose `BaseApp` from package

## Testing
- `pip install -q Panda3D==1.10.15`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854293030e0832e85dc866e4dd798bb