### PR TITLE
Set default window size

### DIFF
--- a/runepy/base_app.py
+++ b/runepy/base_app.py
@@ -1,4 +1,5 @@
 from direct.showbase.ShowBase import ShowBase
+from panda3d.core import loadPrcFileData
 from runepy.loading_screen import LoadingScreen
 
 
@@ -6,6 +7,8 @@ class BaseApp(ShowBase):
     """Application base that shows a loading screen and defers setup."""
 
     def __init__(self):
+        # Set a consistent default window size before ShowBase initializes
+        loadPrcFileData("", "win-size 800 600")
         super().__init__()
         self.loading_screen = LoadingScreen(self)
         self.loading_screen.update(0, "Initializing")


### PR DESCRIPTION
## Summary
- ensure Panda3D starts with a standard window size

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68561f003340832e8d41a16d28d618b8