### PR TITLE
Add terrain tile dataclass

### DIFF
--- a/runepy/__init__.py
+++ b/runepy/__init__.py
@@ -2,11 +2,12 @@
 
 from . import pathfinding
 from .array_map import RegionArrays
+from .terrain import TerrainTile, FLAG_BLOCKED
 
 try:
     from .base_app import BaseApp
 except Exception:
     BaseApp = None  # Panda3D may not be available during tests
 
-__all__ = ["pathfinding", "BaseApp", "RegionArrays"]
+__all__ = ["pathfinding", "BaseApp", "RegionArrays", "TerrainTile", "FLAG_BLOCKED"]
 

--- a/runepy/terrain.py
+++ b/runepy/terrain.py
@@ -1,0 +1,24 @@
+from dataclasses import dataclass
+from typing import Tuple
+
+
+#: Tile flag bitmask for a blocked or non-walkable tile
+FLAG_BLOCKED = 0x1
+
+
+@dataclass
+class TerrainTile:
+    """Tile information used for terrain rendering and collision."""
+
+    corner_heights: Tuple[float, float, float, float] = (0.0, 0.0, 0.0, 0.0)
+    underlay_id: int = 0
+    overlay_id: int = 0
+    overlay_shape: int = 0
+    overlay_rotation: int = 0
+    flags: int = 0
+
+    @property
+    def walkable(self) -> bool:
+        """Return ``True`` if the tile is not marked as blocked."""
+        return not bool(self.flags & FLAG_BLOCKED)
+

--- a/tests/test_terrain_tile.py
+++ b/tests/test_terrain_tile.py
@@ -1,0 +1,19 @@
+from runepy.terrain import TerrainTile, FLAG_BLOCKED
+
+
+def test_terrain_tile_flags_and_values():
+    tile = TerrainTile(
+        corner_heights=(1.0, 2.0, 3.0, 4.0),
+        underlay_id=5,
+        overlay_id=6,
+        overlay_shape=2,
+        overlay_rotation=1,
+        flags=FLAG_BLOCKED,
+    )
+    assert tile.corner_heights == (1.0, 2.0, 3.0, 4.0)
+    assert tile.underlay_id == 5
+    assert tile.overlay_id == 6
+    assert tile.overlay_shape == 2
+    assert tile.overlay_rotation == 1
+    assert tile.flags & FLAG_BLOCKED
+    assert not tile.walkable


### PR DESCRIPTION
## Summary
- support more detailed terrain info with `TerrainTile`
- expose `TerrainTile` and `FLAG_BLOCKED`
- test new dataclass

## Testing
- `pip install -q -r requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856290bb3a8832ea91874573d410309