### PR TITLE
Set default map size to 1000×1000 tiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ To launch the map editor instead of the game, run:
 python -m runepy --mode editor
 ```
 
-A window will open containing a grid of tiles. Clicking on a tile moves the smiley‑face character to that location using pathfinding. Use the mouse wheel to zoom the camera in or out.
+A window will open containing a grid of tiles. By default the world spans 1000×1000 tiles, so there is plenty of space to explore. Clicking on a tile moves the smiley‑face character to that location using pathfinding. Use the mouse wheel to zoom the camera in or out.
 
 Zooming is always handled by the mouse wheel and cannot be changed. In the editor the camera pans up/down with ``W`` and ``S`` while the ``A`` and ``D`` keys for left/right movement remain rebindable.
 

--- a/runepy/world.py
+++ b/runepy/world.py
@@ -60,7 +60,7 @@ except Exception:  # pragma: no cover - Panda3D may be missing during tests
 class World:
     """Generate and display a simple grid-based world."""
 
-    def __init__(self, render, radius=5, tile_size=1, debug=False, map_file=None):
+    def __init__(self, render, radius=500, tile_size=1, debug=False, map_file=None):
         self.render = render
         self.radius = radius
         self.tile_size = tile_size


### PR DESCRIPTION
## Summary
- expand world radius so maps generate at 1000×1000 tiles
- document new map size in README

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858426deac0832ea964a2a5c68777e6