### PR TITLE
Change sky background and add black subfloor

### DIFF
--- a/runepy/client.py
+++ b/runepy/client.py
@@ -63,7 +63,8 @@ class Client(BaseApp):
 
         self.loading_screen.update(80, "Finalizing")
 
-        self.setBackgroundColor(0.9, 0.9, 0.9)
+        # Set a pleasant sky blue background
+        self.setBackgroundColor(0.53, 0.81, 0.92)
         if cam_h is None:
             self.camera.setPos(0, 0, 10)
         self.camera.lookAt(0, 0, 0)

--- a/runepy/editor_window.py
+++ b/runepy/editor_window.py
@@ -55,7 +55,8 @@ class EditorWindow(BaseApp):
         self.accept("s", lambda: self.camera_control.set_move("back", True))
         self.accept("s-up", lambda: self.camera_control.set_move("back", False))
 
-        self.setBackgroundColor(0.9, 0.9, 0.9)
+        # Editor uses the same sky blue background as the game
+        self.setBackgroundColor(0.53, 0.81, 0.92)
 
         self.camera.setPos(0, 0, 10)
         self.camera.lookAt(0, 0, 0)

--- a/runepy/world.py
+++ b/runepy/world.py
@@ -81,12 +81,27 @@ class World:
 
         self._generate_tiles()
         self._create_grid_lines()
+        self._create_subfloor()
         # Flattening tiles would merge them into a single node which prevents
         # per-tile color adjustments. Keep tiles separate so each can be
         # highlighted individually. Grid lines remain flattened for performance.
         self.grid_lines.flattenStrong()
 
         self._hovered = None
+
+    def _create_subfloor(self):
+        """Create a large black plane just below the tiles."""
+        if CardMaker is None:
+            return
+        plane_size = (self.radius * 2 + 4) * self.tile_size
+        cm = CardMaker("subfloor")
+        cm.setFrame(-plane_size / 2, plane_size / 2, -plane_size / 2, plane_size / 2)
+        node = self.render.attachNewNode(cm.generate())
+        node.setPos(0, 0, -1)
+        node.setColor(0, 0, 0, 1)
+        # Ensure the subfloor renders before the tiles
+        node.setBin("background", 0)
+        node.setDepthWrite(False)
 
     def save_map(self, filename):
         """Write the current grid to ``filename`` as JSON."""


### PR DESCRIPTION
## Summary
- update both the client and editor background to a sky blue tone
- create a black subfloor plane below the tiles

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685844d5a7a8832e925538443a5d9e04