### PR TITLE
Optimize large world rendering

### DIFF
--- a/runepy/client.py
+++ b/runepy/client.py
@@ -81,7 +81,7 @@ class Client(BaseApp):
         )
         if mpos:
             self.debug_info.update_tile_info(mpos, tile_x, tile_y)
-            if (tile_x, tile_y) in self.world.tiles:
+            if -self.world.radius <= tile_x <= self.world.radius and -self.world.radius <= tile_y <= self.world.radius:
                 self.world.highlight_tile(tile_x, tile_y)
             else:
                 self.world.clear_highlight()

--- a/runepy/editor_window.py
+++ b/runepy/editor_window.py
@@ -68,7 +68,7 @@ class EditorWindow(BaseApp):
             self.mouseWatcherNode, self.camera, self.render
         )
         if mpos:
-            if (tile_x, tile_y) in self.world.tiles:
+            if -self.world.radius <= tile_x <= self.world.radius and -self.world.radius <= tile_y <= self.world.radius:
                 self.world.highlight_tile(tile_x, tile_y)
             else:
                 self.world.clear_highlight()

--- a/runepy/map_editor.py
+++ b/runepy/map_editor.py
@@ -30,9 +30,7 @@ class MapEditor:
             return
         tile_data = self.world.grid[grid_y][grid_x]
         tile_data.walkable = not tile_data.walkable
-        tile = self.world.tiles.get((tile_x, tile_y))
-        if tile:
-            tile.setColor(self.world._tile_color(tile_data))
+        self.world.update_tile_color(tile_x, tile_y)
 
     def toggle_interactable(self):
         if self.client.options_menu.visible:


### PR DESCRIPTION
## Summary
- remove per-tile NodePaths
- build world mesh in a single Geom
- use a highlight quad overlay
- update editor and client hover logic

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68584e6ac8d0832e917ed42a9f4053f8