### PR TITLE
Fix Geom imports in world module

### DIFF
--- a/runepy/world.py
+++ b/runepy/world.py
@@ -47,6 +47,12 @@ try:
         CardMaker,
         CollisionNode,
         CollisionPlane,
+        Geom,
+        GeomNode,
+        GeomTriangles,
+        GeomVertexData,
+        GeomVertexFormat,
+        GeomVertexWriter,
         Plane,
         Point3,
         Vec3,
@@ -55,6 +61,8 @@ try:
 except Exception:  # pragma: no cover - Panda3D may be missing during tests
     BitMask32 = CardMaker = CollisionNode = CollisionPlane = Plane = None
     Point3 = Vec3 = LineSegs = None
+    Geom = GeomNode = GeomTriangles = None
+    GeomVertexData = GeomVertexFormat = GeomVertexWriter = None
 
 
 class World:


### PR DESCRIPTION
## Summary
- add missing Panda3D Geom-related imports
- handle absent Panda3D by setting names to `None`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for numpy and runepy)*

------
https://chatgpt.com/codex/tasks/task_e_68585217eb0c832e9c96ffe89292d594