### PR TITLE
Improve loading screen with progress callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ RunePy is a small demonstration project built with [Panda3D](https://www.panda3d
 - Camera zoom limits keep the view between a minimum and maximum height
 - Built-in map editor with hotkeys for saving and loading maps
 - Tiles support custom metadata loaded from map files
-- Individual tiles darken slightly when hovered to show the current mouse
-  position
+- Individual tiles darken slightly when hovered to show the current mouse position
+- Loading screen displays progress messages during startup
 
 ## Repository Layout
 

--- a/runepy/client.py
+++ b/runepy/client.py
@@ -35,7 +35,9 @@ class Client(BaseApp):
         self.buttonThrowers[0].node().set_modifier_buttons(ModifierButtons())
 
         self.loading_screen.update(20, "Generating world")
-        self.world = World(self.render, debug=self.debug)
+        def world_progress(frac, text):
+            self.loading_screen.update(20 + int(30 * frac), text)
+        self.world = World(self.render, debug=self.debug, progress_callback=world_progress)
         self.grid = self.world.grid
         self.map_radius = self.world.radius
 


### PR DESCRIPTION
## Summary
- show loading screen progress messages
- expose `progress_callback` in `World` to report loading status
- update client to pass progress updates to the loading bar

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68585441db20832e925e814508c64b13