### PR TITLE
Add coordinate helpers module

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -1,0 +1,2 @@
+REGION_SIZE = 64  # tiles per region
+VIEW_RADIUS = 1  # keeps a 3 × 3 region window in memory

--- a/tests/test_coords.py
+++ b/tests/test_coords.py
@@ -1,0 +1,30 @@
+from constants import REGION_SIZE
+from world.coords import world_to_region, local_tile
+
+
+def round_trip(x, y):
+    rx, ry = world_to_region(x, y)
+    lx, ly = local_tile(x, y)
+    wx = rx * REGION_SIZE + lx
+    wy = ry * REGION_SIZE + ly
+    return wx, wy
+
+
+def test_round_trip_zero():
+    assert round_trip(0, 0) == (0, 0)
+
+
+def test_round_trip_boundary():
+    assert round_trip(63, 63) == (63, 63)
+    assert round_trip(64, 64) == (64, 64)
+
+
+def test_round_trip_misc():
+    samples = [
+        (65, 20),
+        (-1, -1),
+        (-65, -65),
+        (128, 130),
+    ]
+    for x, y in samples:
+        assert round_trip(x, y) == (x, y)

--- a/world/coords.py
+++ b/world/coords.py
@@ -1,0 +1,9 @@
+from constants import REGION_SIZE
+
+
+def world_to_region(x: int, y: int) -> tuple[int, int]:
+    return x // REGION_SIZE, y // REGION_SIZE
+
+
+def local_tile(x: int, y: int) -> tuple[int, int]:
+    return x % REGION_SIZE, y % REGION_SIZE


### PR DESCRIPTION
## Summary
- add `constants` module for region parameters
- create `world.coords` helpers
- test that world-region conversions round trip correctly

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68585bf90208832e960f2f3848249e40