### PR TITLE
Implement RegionManager for region loading

### DIFF
--- a/tests/test_region_manager.py
+++ b/tests/test_region_manager.py
@@ -1,0 +1,26 @@
+import numpy as np
+from world.region_manager import RegionManager
+from world.region import Region
+from constants import REGION_SIZE
+
+
+def test_region_manager_loading(tmp_path, monkeypatch):
+    # Ensure regions are stored in temporary directory
+    monkeypatch.chdir(tmp_path)
+
+    mgr = RegionManager(view_radius=1)
+    # initial position inside region (0,0)
+    mgr.ensure(10, 10)
+    assert len(mgr.loaded) == 9  # 3x3 window
+
+    # move east across region boundary
+    mgr.ensure(REGION_SIZE + 1, 10)
+    assert (1, 0) in mgr.loaded
+    assert len(mgr.loaded) <= 9
+    assert (-1, 0) not in mgr.loaded
+
+    # move north across boundary
+    mgr.ensure(REGION_SIZE + 1, REGION_SIZE + 2)
+    assert (1, 1) in mgr.loaded
+    assert len(mgr.loaded) <= 9
+    assert (0, -1) not in mgr.loaded

--- a/world/__init__.py
+++ b/world/__init__.py
@@ -1,0 +1,5 @@
+from .coords import world_to_region, local_tile
+from .region import Region
+from .region_manager import RegionManager
+
+__all__ = ["Region", "RegionManager", "world_to_region", "local_tile"]

--- a/world/region_manager.py
+++ b/world/region_manager.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from concurrent.futures import Future, ThreadPoolExecutor
+from typing import Dict, Tuple, Set
+
+from constants import VIEW_RADIUS
+from .coords import world_to_region
+from .region import Region
+
+
+class RegionManager:
+    """Manage loading and unloading of ``Region`` objects around a player."""
+
+    def __init__(self, view_radius: int = VIEW_RADIUS, async_load: bool = False) -> None:
+        self.loaded: Dict[Tuple[int, int], Region] = {}
+        self.view_radius = view_radius
+        self.async_load = async_load
+        self._executor: ThreadPoolExecutor | None = None
+        self._pending: Dict[Tuple[int, int], Future[Region]] = {}
+        if async_load:
+            self._executor = ThreadPoolExecutor(max_workers=1)
+
+    # ------------------------------------------------------------------
+    def _wanted(self, rx: int, ry: int) -> Set[Tuple[int, int]]:
+        r = range(-self.view_radius, self.view_radius + 1)
+        return {(rx + i, ry + j) for i in r for j in r}
+
+    # ------------------------------------------------------------------
+    def ensure(self, player_x: int, player_y: int) -> None:
+        """Ensure regions around ``(player_x, player_y)`` are loaded."""
+        rx, ry = world_to_region(player_x, player_y)
+        want = self._wanted(rx, ry)
+
+        # Remove regions that are no longer needed
+        for key in set(self.loaded) - want:
+            region = self.loaded.pop(key)
+            if region.node is not None:
+                region.node.removeNode()
+        # Cancel outstanding loads for regions we no longer care about
+        for key in set(self._pending) - want:
+            future = self._pending.pop(key)
+            future.cancel()
+
+        # Finalize any pending loads that completed
+        for key, future in list(self._pending.items()):
+            if future.done():
+                region = future.result()
+                region.make_mesh()
+                self.loaded[key] = region
+                self._pending.pop(key)
+
+        # Queue or perform loads for any missing regions
+        for key in want - self.loaded.keys() - self._pending.keys():
+            if self.async_load and self._executor is not None:
+                self._pending[key] = self._executor.submit(Region.load, *key)
+            else:
+                region = Region.load(*key)
+                region.make_mesh()
+                self.loaded[key] = region
+
+    # ------------------------------------------------------------------
+    def shutdown(self) -> None:
+        """Clean up any executor threads used for async loading."""
+        if self._executor is not None:
+            self._executor.shutdown(wait=False)
+            self._executor = None


### PR DESCRIPTION
## Summary
- add RegionManager with async loading option
- expose RegionManager from `world` package
- test RegionManager loading behavior

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68585f8cf654832e955482c3c717474f