### PR TITLE
Fix test imports and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,9 +117,11 @@ tile coordinates using the camera and render nodes. Pass the current camera and
 
 ## Tests
 
-Run the test suite with `pytest -q` from the repository root:
+Install the Python dependencies listed in `requirements.txt` and run the
+test suite with `pytest -q` from the repository root:
 
 ```bash
+pip install -r requirements.txt
 pytest -q
 ```
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+# Add repository root to sys.path so tests can import runepy and other modules
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))


### PR DESCRIPTION
## Summary
- add `tests/conftest.py` so pytest adds the project root to `sys.path`
- clarify README about installing requirements before running tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685861744548832eb7ffb211155a6c56