### PR TITLE
Integrate region streaming

### DIFF
--- a/tests/test_world_streaming.py
+++ b/tests/test_world_streaming.py
@@ -1,0 +1,44 @@
+import numpy as np
+from constants import REGION_SIZE
+from world.world import World
+from runepy.terrain import FLAG_BLOCKED
+
+
+def test_update_streaming_calls_ensure(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    w = World(view_radius=1)
+
+    calls = []
+    real_ensure = w.manager.ensure
+
+    def mock_ensure(x, y):
+        calls.append((x, y))
+        real_ensure(x, y)
+
+    monkeypatch.setattr(w.manager, "ensure", mock_ensure)
+
+    w.update_streaming(10, 10)  # first call
+    w.update_streaming(20, 20)  # same region
+    assert len(calls) == 1
+
+    w.update_streaming(REGION_SIZE + 5, 10)  # different region
+    assert len(calls) == 2
+
+
+def test_world_streaming_region_limit(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    w = World(view_radius=1)
+    for x in range(0, REGION_SIZE * 4, REGION_SIZE):
+        for y in range(0, REGION_SIZE * 4, REGION_SIZE):
+            w.update_streaming(x, y)
+            assert len(w.manager.loaded) <= 9
+
+
+def test_is_walkable(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    w = World(view_radius=1)
+    w.update_streaming(0, 0)
+    region = w.manager.loaded[(0, 0)]
+    region.flags[1, 1] = FLAG_BLOCKED
+    assert not w.is_walkable(1, 1)
+    assert w.is_walkable(2, 2)

--- a/world/__init__.py
+++ b/world/__init__.py
@@ -2,4 +2,5 @@ from .coords import world_to_region, local_tile
 from .region import Region
 from .region_manager import RegionManager
 
-__all__ = ["Region", "RegionManager", "world_to_region", "local_tile"]
+from .world import World
+__all__ = ["Region", "RegionManager", "World", "world_to_region", "local_tile"]

--- a/world/world.py
+++ b/world/world.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from .coords import world_to_region, local_tile
+from .region_manager import RegionManager
+from runepy.terrain import FLAG_BLOCKED
+
+
+class World:
+    """World that streams regions using :class:`RegionManager`."""
+
+    def __init__(self, view_radius: int = 1) -> None:
+        self.manager = RegionManager(view_radius=view_radius)
+        self._current_region: tuple[int, int] | None = None
+
+    # ------------------------------------------------------------------
+    def update_streaming(self, player_x: int, player_y: int) -> None:
+        """Ensure surrounding regions for ``(player_x, player_y)`` are loaded."""
+        rx, ry = world_to_region(player_x, player_y)
+        if self._current_region != (rx, ry):
+            self._current_region = (rx, ry)
+            self.manager.ensure(player_x, player_y)
+
+    # ------------------------------------------------------------------
+    def is_walkable(self, x: int, y: int) -> bool:
+        """Return ``True`` if tile ``(x, y)`` is not flagged as blocked."""
+        rx, ry = world_to_region(x, y)
+        region = self.manager.loaded.get((rx, ry))
+        if region is None:
+            self.manager.ensure(x, y)
+            region = self.manager.loaded.get((rx, ry))
+            if region is None:
+                return False
+        lx, ly = local_tile(x, y)
+        return not bool(region.flags[ly, lx] & FLAG_BLOCKED)
+
+    # ------------------------------------------------------------------
+    def shutdown(self) -> None:
+        """Shut down the underlying :class:`RegionManager`."""
+        self.manager.shutdown()


### PR DESCRIPTION
## Summary
- add new `World` that streams `Region` objects on demand
- export `World` from the `world` package
- test world streaming logic and walkability

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858632d4128832eb5abdea209f45857