### PR TITLE
Add streaming hooks and region debug overlay

### DIFF
--- a/runepy/character.py
+++ b/runepy/character.py
@@ -1,10 +1,11 @@
 #Character.py
 from panda3d.core import Vec3
 from direct.interval.IntervalGlobal import Func, LerpPosInterval, Sequence
+from world.coords import world_to_region
 
 class Character:
 
-    def __init__(self, render, loader, position=Vec3(0, 0, 0), scale=1, debug=False):
+    def __init__(self, render, loader, position=Vec3(0, 0, 0), scale=1, debug=False, world=None):
         self.debug = debug
         self.model = loader.loadModel("models/smiley")
         self.model.reparentTo(render)
@@ -13,6 +14,11 @@ class Character:
 
         # Base movement speed in tiles per second
         self.speed = 1.0
+        self.world = world
+        if world is not None:
+            self._current_region = world_to_region(int(position.getX()), int(position.getY()))
+        else:
+            self._current_region = None
 
         self._active_sequence = None
 
@@ -20,18 +26,28 @@ class Character:
         if self.debug:
             print(*args, **kwargs)
 
-    def move_to(self, target_pos, duration):
+    def move_to(self, target_pos, duration, after_step=None):
         """Create a movement interval towards ``target_pos`` taking ``duration`` seconds."""
-        self.log(f"Inside move_to. Target: {target_pos} Duration: {duration}")
-
         move_interval = LerpPosInterval(self.model, duration=duration, pos=target_pos)
+        if after_step:
+            return Sequence(move_interval, Func(after_step), Func(self.stop))
         return Sequence(move_interval, Func(self.stop))
 
     def get_position(self):
         return self.model.getPos()
 
+    def _check_region_update(self):
+        if self.world is None:
+            return
+        pos = self.model.getPos()
+        rx, ry = world_to_region(int(pos.getX()), int(pos.getY()))
+        if (rx, ry) != self._current_region:
+            self._current_region = (rx, ry)
+            self.world.update_streaming(int(pos.getX()), int(pos.getY()))
+
     def stop(self):
         self.log("Movement finished")
+        self._check_region_update()
 
     def cancel_movement(self):
         """Stop the current movement without jumping to the end position."""

--- a/runepy/client.py
+++ b/runepy/client.py
@@ -62,6 +62,7 @@ class Client(BaseApp):
         self.key_manager.bind("open_menu", self.options_menu.toggle)
 
         self.accept("mouse1", self.tile_click_event)
+        self.accept("f3", self.debug_info.toggle_region_info)
 
         self.loading_screen.update(80, "Finalizing")
 

--- a/runepy/debuginfo.py
+++ b/runepy/debuginfo.py
@@ -6,10 +6,12 @@ class DebugInfo:
     def __init__(self):
         self.text_object = OnscreenText(text="", pos=(-1.3, 0.9), scale=0.05,
                                         fg=(1, 1, 1, 1), align=TextNode.ALeft)
+        self.region_text = OnscreenText(text="", pos=(-1.3, 0.8), scale=0.05,
+                                        fg=(1, 1, 1, 1), align=TextNode.ALeft)
+        self.region_text.hide()
 
     def update_tile_info(self, mpos, tile_x, tile_y):
         self.text_object.setText(f"Mouse: ({mpos.getX()}, {mpos.getY()})\nTile: ({tile_x}, {tile_y})")
-        #print(f"Mouse: ({mpos.getX()}, {mpos.getY()}) - Tile: ({tile_x}, {tile_y})")
 
     def update_distance_from_center(self, tile_x, tile_y):
         distance = (Vec3(tile_x, tile_y, 0) - Vec3(0, 0, 0)).length()
@@ -17,3 +19,12 @@ class DebugInfo:
         current_text = self.text_object.getText()
         new_text = current_text + f"\nDistance: {distance:.2f}\nDirection: ({direction.getX():.2f}, {direction.getY():.2f})"
         self.text_object.setText(new_text)
+
+    def toggle_region_info(self):
+        if self.region_text.isHidden():
+            self.region_text.show()
+        else:
+            self.region_text.hide()
+
+    def update_region_info(self, rx, ry, count):
+        self.region_text.setText(f"Region: ({rx}, {ry})\nLoaded: {count}")

--- a/tests/test_region.py
+++ b/tests/test_region.py
@@ -1,0 +1,19 @@
+import numpy as np
+from world.region import Region
+from constants import REGION_SIZE
+
+
+def test_region_edit_round_trip(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    r = Region.load(0, 0)
+    r.height[0, 0] = 5
+    r.base[1, 1] = 2
+    r.overlay[2, 2] = 3
+    r.flags[3, 3] = 4
+    r.save()
+
+    loaded = Region.load(0, 0)
+    assert np.array_equal(r.height, loaded.height)
+    assert np.array_equal(r.base, loaded.base)
+    assert np.array_equal(r.overlay, loaded.overlay)
+    assert np.array_equal(r.flags, loaded.flags)

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -1,0 +1,13 @@
+from constants import REGION_SIZE
+from world.world import World
+
+
+def test_streaming_consistency(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    w = World(view_radius=1)
+    for i in range(10):
+        x = (i + 1) * REGION_SIZE
+        w.update_streaming(x, 0)
+        assert len(w.manager.loaded) <= 9
+    w.update_streaming(0, 0)
+    assert len(w.manager.loaded) <= 9


### PR DESCRIPTION
## Summary
- trigger region streaming after character steps
- add region info overlay and toggle with F3
- unit tests for Region round-trip and streaming

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685865614fcc832ebd733bae22725f1e