### PR TITLE
Add debug scaffolding

### DIFF
--- a/runepy/debug/__init__.py
+++ b/runepy/debug/__init__.py
@@ -1,0 +1,51 @@
+"""Debug utilities for RunePy.
+
+This module exposes a :class:`DebugManager` singleton via :func:`get_debug`.
+Importing the package will not raise ImportError even if Panda3D's ``direct``
+module is unavailable.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+try:
+    from .gui import DebugWindow  # type: ignore
+except Exception:  # pragma: no cover - GUI components may not be present
+    DebugWindow = None  # type: ignore
+
+
+class DebugManager:
+    """Simple container for debug helpers."""
+
+    def __init__(self) -> None:
+        self.window: Optional[DebugWindow] = None
+        if DebugWindow is not None:
+            try:
+                self.window = DebugWindow(self)
+            except Exception:
+                # Failed to initialize debug window (likely no Panda3D)
+                self.window = None
+
+    def toggle(self) -> None:
+        """Toggle visibility of the debug window if available."""
+        if self.window is None:
+            return
+        if self.window.isHidden():
+            self.window.show()
+        else:
+            self.window.hide()
+
+
+_debug_instance: Optional[DebugManager] = None
+
+
+def get_debug() -> DebugManager:
+    """Return the shared :class:`DebugManager` instance."""
+    global _debug_instance
+    if _debug_instance is None:
+        _debug_instance = DebugManager()
+    return _debug_instance
+
+
+__all__ = ["DebugManager", "get_debug"]

--- a/runepy/debug/gui.py
+++ b/runepy/debug/gui.py
@@ -1,0 +1,47 @@
+"""GUI components for debugging.
+
+This module wraps Panda3D's DirectGUI widgets. It can be imported safely even
+when Panda3D is not available.
+"""
+
+from __future__ import annotations
+
+try:
+    from direct.gui.DirectGui import (
+        DirectFrame,
+        DirectButton,
+        DirectSlider,
+        DirectLabel,
+    )
+    from direct.task import Task
+except Exception:  # pragma: no cover - Panda3D may be missing
+    DirectFrame = object  # type: ignore
+    DirectButton = object  # type: ignore
+    DirectSlider = object  # type: ignore
+    DirectLabel = object  # type: ignore
+    Task = object  # type: ignore
+
+
+class DebugWindow(DirectFrame):
+    def __init__(self, mgr) -> None:
+        super().__init__(
+            frameColor=(0, 0, 0, 0.7),
+            frameSize=(-0.6, 0.6, -0.4, 0.4),
+            pos=(0.7, 0, 0.55),
+        )
+        self.mgr = mgr  # back-reference
+        self._build_live_stats()
+        self._build_actions()
+        self._build_tweaks()
+        self.hide()
+
+    def _build_live_stats(self) -> None:
+        pass
+
+    def _build_actions(self) -> None:
+        pass
+
+    def _build_tweaks(self) -> None:
+        pass
+
+__all__ = ["DebugWindow"]


### PR DESCRIPTION
## Summary
- scaffold `runepy.debug` package
- implement singleton `DebugManager` and `get_debug()`
- add stub `DebugWindow` GUI class guarded against missing Panda3D

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685870d75cc8832e94ae74089e229db9