### PR TITLE
Add live debug stats and actions

### DIFF
--- a/runepy/client.py
+++ b/runepy/client.py
@@ -1,4 +1,5 @@
 from panda3d.core import ModifierButtons, Vec3
+from direct.showbase.ShowBaseGlobal import base
 from runepy.utils import get_mouse_tile_coords, get_tile_from_mouse
 from direct.interval.IntervalGlobal import Sequence, Func
 import math
@@ -41,7 +42,9 @@ class Client(BaseApp):
 
         tile_fit_scale = self.world.tile_size * 0.5
         self.loading_screen.update(50, "Loading character")
+        base.world = self.world
         self.character = Character(self.render, self.loader, Vec3(0, 0, 0.5), scale=tile_fit_scale, debug=self.debug)
+        base.character = self.character
         self.camera_control = CameraControl(self.camera, self.render, self.character)
 
         # Load persisted state if available

--- a/runepy/debug/__init__.py
+++ b/runepy/debug/__init__.py
@@ -6,6 +6,8 @@ module is unavailable.
 """
 
 from __future__ import annotations
+from pathlib import Path
+import datetime
 
 from typing import Optional
 
@@ -19,6 +21,7 @@ class DebugManager:
     """Simple container for debug helpers."""
 
     def __init__(self) -> None:
+        self.log_file: Optional[Path] = None
         self.window: Optional[DebugWindow] = None
         if DebugWindow is not None:
             try:
@@ -26,6 +29,15 @@ class DebugManager:
             except Exception:
                 # Failed to initialize debug window (likely no Panda3D)
                 self.window = None
+
+    def enable(self) -> None:
+        if self.window is None:
+            return
+        try:
+            from direct.showbase.ShowBaseGlobal import taskMgr
+            taskMgr.doMethodLater(0.5, self.window.refresh_task, "dbg-refresh")
+        except Exception:
+            pass
 
     def toggle(self) -> None:
         """Toggle visibility of the debug window if available."""
@@ -36,6 +48,66 @@ class DebugManager:
         else:
             self.window.hide()
 
+
+    def _stats(self):
+        try:
+            from direct.showbase.ShowBaseGlobal import base, render
+            world = getattr(base, "world", None)
+            if world is None:
+                return 0, 0
+            rm = world.region_manager
+            regions = len(rm.loaded)
+            geoms = render.findAllMatches("**/+GeomNode").getNumPaths()
+            return regions, geoms
+        except Exception:
+            return 0, 0
+
+    def dump_console(self):
+        regions, geoms = self._stats()
+        print(f"{datetime.datetime.now().isoformat()} regions={regions} geoms={geoms}")
+
+    def dump_file(self):
+        regions, geoms = self._stats()
+        if self.log_file is None:
+            ts = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+            self.log_file = Path(f"debug_{ts}.txt")
+        with self.log_file.open("a") as f:
+            f.write(f"{datetime.datetime.now().isoformat()} {regions} {geoms}\n")
+
+    def toggle_pstats(self):
+        try:
+            from direct.showbase.ShowBaseGlobal import base
+            if getattr(base, "pstats", None):
+                base.stopPStats()
+            else:
+                base.startPStats("localhost", 5185)
+        except Exception:
+            pass
+
+    def reload_region(self):
+        try:
+            from direct.showbase.ShowBaseGlobal import base
+            from runepy.world import world_to_region, Region, REGION_SIZE
+            world = getattr(base, "world", None)
+            char = getattr(base, "character", None)
+            if world is None or char is None:
+                return
+            x = int(char.model.getX())
+            y = int(char.model.getY())
+            rx, ry = world_to_region(x, y)
+            region = world.region_manager.loaded.get((rx, ry))
+            if region is None:
+                return
+            region.save()
+            new_region = Region.load(rx, ry)
+            new_region.make_mesh()
+            parent = getattr(base, "tile_root", base.render)
+            if new_region.node is not None:
+                new_region.node.reparentTo(parent)
+                new_region.node.setPos(rx * REGION_SIZE, ry * REGION_SIZE, 0)
+            world.region_manager.loaded[(rx, ry)] = new_region
+        except Exception:
+            pass
 
 _debug_instance: Optional[DebugManager] = None
 

--- a/runepy/debug/gui.py
+++ b/runepy/debug/gui.py
@@ -36,10 +36,29 @@ class DebugWindow(DirectFrame):
         self.hide()
 
     def _build_live_stats(self) -> None:
-        pass
+        self.stats_lbl = DirectLabel(text="", parent=self, pos=(-0.55, 0, 0.25), scale=0.05)
+
+    def refresh_task(self, task: "Task"):
+        from direct.showbase.ShowBaseGlobal import base, render
+        world = getattr(base, "world", None)
+        if world is not None:
+            rm = world.region_manager
+            regions = len(rm.loaded)
+        else:
+            regions = 0
+        geoms = render.findAllMatches("**/+GeomNode").getNumPaths()
+        self.stats_lbl["text"] = f"Regions: {regions:2d}\nGeoms:   {geoms:3d}"
+        return task.again
 
     def _build_actions(self) -> None:
-        pass
+        y = 0.1
+        DirectButton(text="Dump to console", command=self.mgr.dump_console, pos=(-0.45, 0, y), scale=0.05, parent=self)
+        y -= 0.1
+        DirectButton(text="Dump to file", command=self.mgr.dump_file, pos=(-0.45, 0, y), scale=0.05, parent=self)
+        y -= 0.1
+        DirectButton(text="Toggle PStats", command=self.mgr.toggle_pstats, pos=(-0.45, 0, y), scale=0.05, parent=self)
+        y -= 0.1
+        DirectButton(text="Reload region", command=self.mgr.reload_region, pos=(-0.45, 0, y), scale=0.05, parent=self)
 
     def _build_tweaks(self) -> None:
         pass


### PR DESCRIPTION
## Summary
- implement live stats refresh and action buttons in debug GUI
- add debug manager helpers for console/file dumps, PStats toggle, and region reload
- expose world and character via `base` for debug helpers

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858719840dc832e8751207cffc1219a