### PR TITLE
Add draggable debug overlay and stub tests

### DIFF
--- a/runepy/client.py
+++ b/runepy/client.py
@@ -19,6 +19,7 @@ from runepy.pathfinding import a_star
 from runepy.collision import CollisionControl
 from runepy.options_menu import KeyBindingManager, OptionsMenu
 from runepy.loading_screen import LoadingScreen
+from runepy.debug import get_debug
 from config import load_state, save_state
 import atexit
 
@@ -42,6 +43,7 @@ class Client(BaseApp):
         def world_progress(frac, text):
             self.loading_screen.update(20 + int(30 * frac), text)
         self.world = World(self.render, debug=self.debug, progress_callback=world_progress)
+        get_debug().attach(self)
 
         tile_fit_scale = self.world.tile_size * 0.5
         self.loading_screen.update(50, "Loading character")

--- a/runepy/debug/__init__.py
+++ b/runepy/debug/__init__.py
@@ -9,12 +9,39 @@ from __future__ import annotations
 from pathlib import Path
 import datetime
 
-from typing import Optional
+from typing import Optional, Any
 
 try:
     from .gui import DebugWindow  # type: ignore
 except Exception:  # pragma: no cover - GUI components may not be present
     DebugWindow = None  # type: ignore
+
+class NullDebugManager:
+    """Fallback manager used when Panda3D is unavailable."""
+
+    def __init__(self) -> None:
+        self.window = None
+
+    def attach(self, base: Any | None = None) -> None:
+        pass
+
+    def enable(self) -> None:
+        pass
+
+    def toggle(self) -> None:
+        pass
+
+    def dump_console(self) -> None:
+        pass
+
+    def dump_file(self) -> None:
+        pass
+
+    def toggle_pstats(self) -> None:
+        pass
+
+    def reload_region(self) -> None:
+        pass
 
 
 class DebugManager:
@@ -26,9 +53,19 @@ class DebugManager:
         if DebugWindow is not None:
             try:
                 self.window = DebugWindow(self)
+                try:
+                    from direct.showbase.ShowBaseGlobal import base
+                    from direct.gui.DirectGui import DirectGuiGlobals as DGG
+                    base.accept('f1', self.window.toggleVisible)
+                    self.window.bind(DGG.B1PRESS, self._start_drag)
+                    self.window.bind(DGG.B1RELEASE, self._end_drag)
+                except Exception:
+                    pass
             except Exception:
                 # Failed to initialize debug window (likely no Panda3D)
                 self.window = None
+        self._drag_start = None
+        self._orig_pos = None
 
     def enable(self) -> None:
         if self.window is None:
@@ -47,6 +84,46 @@ class DebugManager:
             self.window.show()
         else:
             self.window.hide()
+
+    def _start_drag(self, _evt: Any | None = None) -> None:
+        if self.window is None:
+            return
+        try:
+            from direct.showbase.ShowBaseGlobal import base
+        except Exception:
+            return
+        if not base.mouseWatcherNode.hasMouse():
+            return
+        self._drag_start = base.mouseWatcherNode.getMouse()
+        self._orig_pos = self.window.getPos()
+        try:
+            base.taskMgr.add(self._drag_task, "debug-drag")
+        except Exception:
+            pass
+
+    def _drag_task(self, task):
+        if self.window is None or self._drag_start is None or self._orig_pos is None:
+            return task.done
+        try:
+            from direct.showbase.ShowBaseGlobal import base
+        except Exception:
+            return task.done
+        if not base.mouseWatcherNode.hasMouse():
+            return task.cont
+        cur = base.mouseWatcherNode.getMouse()
+        dx = cur[0] - self._drag_start[0]
+        dy = cur[1] - self._drag_start[1]
+        self.window.setPos(self._orig_pos[0] + dx, 0, self._orig_pos[2] + dy)
+        return task.cont
+
+    def _end_drag(self, _evt: Any | None = None) -> None:
+        self._drag_start = None
+        self._orig_pos = None
+        try:
+            from direct.showbase.ShowBaseGlobal import base
+            base.taskMgr.remove("debug-drag")
+        except Exception:
+            pass
 
 
     def _stats(self):
@@ -109,6 +186,10 @@ class DebugManager:
         except Exception:
             pass
 
+    def attach(self, base: Any) -> None:
+        """Hook the debug window into the running ShowBase instance."""
+        self.enable()
+
 _debug_instance: Optional[DebugManager] = None
 
 
@@ -116,7 +197,13 @@ def get_debug() -> DebugManager:
     """Return the shared :class:`DebugManager` instance."""
     global _debug_instance
     if _debug_instance is None:
-        _debug_instance = DebugManager()
+        if DebugWindow is None:
+            _debug_instance = NullDebugManager()  # type: ignore[assignment]
+        else:
+            try:
+                _debug_instance = DebugManager()
+            except Exception:
+                _debug_instance = NullDebugManager()  # type: ignore[assignment]
     return _debug_instance
 
 

--- a/runepy/editor_window.py
+++ b/runepy/editor_window.py
@@ -5,6 +5,7 @@ from runepy.camera import FreeCameraControl
 from runepy.options_menu import KeyBindingManager, OptionsMenu
 from runepy.controls import Controls
 from runepy.utils import get_mouse_tile_coords, get_tile_from_mouse
+from runepy.debug import get_debug
 
 
 
@@ -16,6 +17,7 @@ class EditorWindow(BaseApp):
 
     def initialize(self):
         self.world = World(self.render)
+        get_debug().attach(self)
         self.editor = MapEditor(self, self.world)
         self.editor.save_callback = self.save_map
         self.editor.load_callback = self.load_map

--- a/tests/test_debug_stub.py
+++ b/tests/test_debug_stub.py
@@ -1,0 +1,5 @@
+import runepy.debug as dbg
+
+def test_debug_stub():
+    d = dbg.get_debug()
+    assert hasattr(d, 'dump_console')


### PR DESCRIPTION
## Summary
- expose a NullDebugManager for Panda-less environments
- let DebugManager toggle via F1 and drag window with the mouse
- hook debug manager into Client and EditorWindow
- add unit test verifying stub creation

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685879844a18832eb454e7f5e28d0f9b