### PR TITLE
Refactor debug window to data-driven layout

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,1 +1,2 @@
 Add F1 Debug Window with live stats, actions, and variable tweaks
+Add data-driven debug window builder

--- a/runepy/debug/gui.py
+++ b/runepy/debug/gui.py
@@ -1,86 +1,22 @@
-"""GUI components for debugging.
-
-This module wraps Panda3D's DirectGUI widgets. It can be imported safely even
-when Panda3D is not available.
-"""
-
+"""GUI components for debugging."""
 from __future__ import annotations
 
 try:
-    from direct.gui.DirectGui import (
-        DirectFrame,
-        DirectButton,
-        DirectSlider,
-        DirectLabel,
-    )
+    from direct.gui.DirectGui import DirectFrame
     from direct.task import Task
 except Exception:  # pragma: no cover - Panda3D may be missing
     DirectFrame = object  # type: ignore
-    DirectButton = object  # type: ignore
-    DirectSlider = object  # type: ignore
-    DirectLabel = object  # type: ignore
     Task = object  # type: ignore
+
+from runepy.ui.builder import build_ui
+from runepy.ui.debug_layout import LAYOUT as L
 
 
 class DebugWindow(DirectFrame):
-    def __init__(self, mgr) -> None:
-        super().__init__(
-            frameColor=(0, 0, 0, 0.7),
-            frameSize=(-0.6, 0.6, -0.4, 0.4),
-            pos=(0.7, 0, 0.55),
-        )
-        self.mgr = mgr  # back-reference
-        self._build_live_stats()
-        self._build_actions()
-        self._build_tweaks()
+    def __init__(self, manager) -> None:
+        super().__init__()
+        self.widgets = build_ui(self, L, manager)
         self.hide()
-
-    def _build_live_stats(self) -> None:
-        self.stats_lbl = DirectLabel(text="", parent=self, pos=(-0.55, 0, 0.25), scale=0.05)
-
-    def refresh_task(self, task: "Task"):
-        from direct.showbase.ShowBaseGlobal import base, render
-        world = getattr(base, "world", None)
-        if world is not None:
-            rm = world.region_manager
-            regions = len(rm.loaded)
-        else:
-            regions = 0
-        geoms = render.findAllMatches("**/+GeomNode").getNumPaths()
-        self.stats_lbl["text"] = f"Regions: {regions:2d}\nGeoms:   {geoms:3d}"
-        return task.again
-
-    def _build_actions(self) -> None:
-        y = 0.1
-        DirectButton(text="Dump to console", command=self.mgr.dump_console, pos=(-0.45, 0, y), scale=0.05, parent=self)
-        y -= 0.1
-        DirectButton(text="Dump to file", command=self.mgr.dump_file, pos=(-0.45, 0, y), scale=0.05, parent=self)
-        y -= 0.1
-        DirectButton(text="Toggle PStats", command=self.mgr.toggle_pstats, pos=(-0.45, 0, y), scale=0.05, parent=self)
-        y -= 0.1
-        DirectButton(text="Reload region", command=self.mgr.reload_region, pos=(-0.45, 0, y), scale=0.05, parent=self)
-
-    def _build_tweaks(self) -> None:
-        try:
-            from direct.showbase.ShowBaseGlobal import base
-        except Exception:
-            return
-
-        def add_slider(y, text, min_, max_, getter, setter):
-            DirectLabel(parent=self, text=text, pos=(-0.55, 0, y + 0.02), scale=0.05)
-            try:
-                value = getter()
-                slider = DirectSlider(parent=self, range=(min_, max_), value=value, pos=(-0.05, 0, y), scale=0.4, command=lambda v: setter(float(v)))
-            except Exception:
-                slider = DirectSlider(parent=self, range=(min_, max_), value=min_, pos=(-0.05, 0, y), scale=0.4, state="disabled")
-            return slider
-
-        y = -0.15
-        add_slider(y, "Avatar speed", 0.5, 10.0, lambda: base.player.walk_speed, lambda v: base.player.set_speed(v))
-        y -= 0.1
-        add_slider(y, "Cam pan-speed", 1.0, 40.0, lambda: base.camera_ctl.pan_speed, lambda v: base.camera_ctl.set_pan_speed(v))
-        y -= 0.1
-        add_slider(y, "Zoom step", 0.1, 5.0, lambda: base.camera_ctl.zoom_step, lambda v: base.camera_ctl.set_zoom_step(v))
 
     # ------------------------------------------------------------------
     def toggleVisible(self):
@@ -88,5 +24,21 @@ class DebugWindow(DirectFrame):
             self.show()
         else:
             self.hide()
+
+    def refresh_task(self, task: "Task"):
+        try:
+            from direct.showbase.ShowBaseGlobal import base, render
+        except Exception:
+            return task.again
+        world = getattr(base, "world", None)
+        if world is not None:
+            rm = world.region_manager
+            regions = len(rm.loaded)
+        else:
+            regions = 0
+        geoms = render.findAllMatches("**/+GeomNode").getNumPaths()
+        self.widgets["stats"]["text"] = f"Regions: {regions:2d}\nGeoms:   {geoms:3d}"
+        return task.again
+
 
 __all__ = ["DebugWindow"]

--- a/runepy/debug/manager.py
+++ b/runepy/debug/manager.py
@@ -165,7 +165,55 @@ class DebugManager:
                 new_region.node.reparentTo(parent)
                 new_region.node.setPos(rx * REGION_SIZE, ry * REGION_SIZE, 0)
             world.region_manager.loaded[(rx, ry)] = new_region
+        except Exception: pass
+
+    def get_avatar_speed(self) -> float:
+        try:
+            from direct.showbase.ShowBaseGlobal import base
+            return base.player.walk_speed
         except Exception:
+            try:
+                return base.character.speed
+            except Exception:
+                return 0.0
+
+    def set_avatar_speed(self, value: float) -> None:
+        try:
+            from direct.showbase.ShowBaseGlobal import base
+            if hasattr(base.player, "set_speed"):
+                base.player.set_speed(value)
+            elif hasattr(base.character, "speed"):
+                base.character.speed = value
+        except Exception:
+            pass
+
+    def get_cam_pan_speed(self) -> float:
+        try:
+            from direct.showbase.ShowBaseGlobal import base
+            return base.camera_ctl.pan_speed
+        except Exception:
+            return 0.0
+
+    def set_cam_pan_speed(self, value: float) -> None:
+        try:
+            from direct.showbase.ShowBaseGlobal import base
+            base.camera_ctl.set_pan_speed(value)
+        except Exception:
+            pass
+
+    def get_zoom_step(self) -> float:
+        try:
+            from direct.showbase.ShowBaseGlobal import base
+            return base.camera_ctl.zoom_step
+        except Exception:
+            return 0.0
+
+    def set_zoom_step(self, value: float) -> None:
+        try:
+            from direct.showbase.ShowBaseGlobal import base
+            base.camera_ctl.set_zoom_step(value)
+        except Exception:
+            pass
             pass
 
     def attach(self, base: Any) -> None:
@@ -178,7 +226,7 @@ class DebugManager:
         self.base = base
 
         # 1. Create the window lazily to avoid Panda3D dependency during tests
-        from .gui import DebugWindow
+        from runepy.debug.gui import DebugWindow
         try:
             self.window = DebugWindow(self)
         except Exception:
@@ -194,7 +242,7 @@ class DebugManager:
 
         # 3. Optional debug echo
         if __debug__:
-            print('[DebugManager] F1 bound – press to toggle debug window')
+            print('[DebugManager] F1 bound')
 
         self.enable()
 

--- a/runepy/ui/builder.py
+++ b/runepy/ui/builder.py
@@ -1,0 +1,136 @@
+"""Utility to build UI widgets from a layout dictionary."""
+from __future__ import annotations
+
+from typing import Any, Dict
+
+try:
+    from direct.gui.DirectGui import DirectFrame, DirectButton, DirectSlider, DirectLabel
+except Exception:  # pragma: no cover - Panda3D may be missing
+    DirectFrame = None  # type: ignore
+    DirectButton = None  # type: ignore
+    DirectSlider = None  # type: ignore
+    DirectLabel = None  # type: ignore
+
+
+class StubWidget:
+    """Fallback widget used when Panda3D is unavailable."""
+
+    def __init__(self, **kwargs: Any) -> None:
+        self._props: Dict[str, Any] = kwargs
+
+    def hide(self) -> None:  # pragma: no cover - stub
+        pass
+
+    def show(self) -> None:  # pragma: no cover - stub
+        pass
+
+    def destroy(self) -> None:  # pragma: no cover - stub
+        pass
+
+    def setPythonTag(self, *args: Any) -> None:  # pragma: no cover - stub
+        pass
+
+    def __getitem__(self, key: str) -> Any:  # pragma: no cover - stub
+        return self._props.get(key)
+
+    def __setitem__(self, key: str, value: Any) -> None:  # pragma: no cover - stub
+        self._props[key] = value
+
+
+_WIDGETS = {
+    "frame": DirectFrame or StubWidget,
+    "label": DirectLabel or StubWidget,
+    "button": DirectButton or StubWidget,
+    "slider": DirectSlider or StubWidget,
+}
+
+
+def _make_widget(kind: str, parent: Any, **kwargs: Any) -> Any:
+    cls = _WIDGETS[kind]
+    if cls is None:
+        cls = StubWidget
+    w = cls(parent=parent, **kwargs)
+    if hasattr(w, "setPythonTag"):
+        w.setPythonTag("debug_gui", True)
+    return w
+
+
+def build_ui(parent: Any, layout: Dict[str, Any], manager: Any | None = None) -> Dict[str, Any]:
+    """Create widgets from ``layout`` and return them in a dict."""
+
+    widgets: Dict[str, Any] = {}
+
+    def _build(node: Dict[str, Any], parent_node: Any) -> None:
+        kind = node.get("type")
+        name = node.get("name")
+        children = node.get("children", [])
+        params = {
+            k: v
+            for k, v in node.items()
+            if k
+            not in {
+                "type",
+                "name",
+                "children",
+                "command",
+                "getter",
+                "setter",
+                "label",
+                "label_pos",
+                "label_scale",
+                "range",
+            }
+        }
+
+        if kind == "button":
+            cmd_name = node.get("command")
+            cmd = getattr(manager, cmd_name) if manager and cmd_name and hasattr(manager, cmd_name) else None
+            if cmd is not None:
+                params["command"] = cmd
+            widget = _make_widget("button", parent_node, **params)
+        elif kind == "slider":
+            label_text = node.get("label") or node.get("text")
+            label_pos = node.get("label_pos")
+            label_scale = node.get("label_scale")
+            if label_text is not None:
+                lkw = {"text": label_text}
+                if label_pos is not None:
+                    lkw["pos"] = tuple(label_pos)
+                if label_scale is not None:
+                    lkw["scale"] = label_scale
+                _make_widget("label", parent_node, **lkw)
+            getter_name = node.get("getter")
+            setter_name = node.get("setter")
+            rng = node.get("range")
+            if rng is not None:
+                params["range"] = tuple(rng)
+            if getter_name and manager and hasattr(manager, getter_name):
+                try:
+                    params["value"] = getattr(manager, getter_name)()
+                except Exception:
+                    pass
+            if setter_name and manager and hasattr(manager, setter_name):
+                def _cb(v: Any, m=manager, n=setter_name):
+                    try:
+                        getattr(m, n)(float(v))
+                    except Exception:
+                        pass
+                params["command"] = _cb
+            widget = _make_widget("slider", parent_node, **params)
+        elif kind == "label":
+            widget = _make_widget("label", parent_node, **params)
+        elif kind == "frame":
+            widget = _make_widget("frame", parent_node, **params)
+        else:
+            return
+
+        if name:
+            widgets[name] = widget
+        for child in children:
+            _build(child, widget)
+
+    _build(layout, parent)
+    return widgets
+
+__all__ = ["build_ui", "StubWidget"]
+

--- a/runepy/ui/debug_layout.py
+++ b/runepy/ui/debug_layout.py
@@ -1,0 +1,88 @@
+"""Layout description for the debug overlay."""
+
+LAYOUT = {
+    "type": "frame",
+    "frameColor": (0, 0, 0, 0.7),
+    "frameSize": (-0.6, 0.6, -0.4, 0.4),
+    "pos": (0.7, 0, 0.55),
+    "children": [
+        {
+            "type": "label",
+            "name": "stats",
+            "text": "",
+            "pos": (-0.55, 0, 0.25),
+            "scale": 0.05,
+        },
+        {
+            "type": "button",
+            "name": "dump_console",
+            "text": "Dump to console",
+            "pos": (-0.45, 0, 0.1),
+            "scale": 0.05,
+            "command": "dump_console",
+        },
+        {
+            "type": "button",
+            "name": "dump_file",
+            "text": "Dump to file",
+            "pos": (-0.45, 0, 0.0),
+            "scale": 0.05,
+            "command": "dump_file",
+        },
+        {
+            "type": "button",
+            "name": "toggle_pstats",
+            "text": "Toggle PStats",
+            "pos": (-0.45, 0, -0.1),
+            "scale": 0.05,
+            "command": "toggle_pstats",
+        },
+        {
+            "type": "button",
+            "name": "reload_region",
+            "text": "Reload region",
+            "pos": (-0.45, 0, -0.2),
+            "scale": 0.05,
+            "command": "reload_region",
+        },
+        {
+            "type": "slider",
+            "name": "avatar_speed",
+            "label": "Avatar speed",
+            "pos": (-0.05, 0, -0.15),
+            "label_pos": (-0.55, 0, -0.13),
+            "scale": 0.4,
+            "label_scale": 0.05,
+            "range": (0.5, 10.0),
+            "getter": "get_avatar_speed",
+            "setter": "set_avatar_speed",
+        },
+        {
+            "type": "slider",
+            "name": "cam_pan_speed",
+            "label": "Cam pan-speed",
+            "pos": (-0.05, 0, -0.25),
+            "label_pos": (-0.55, 0, -0.23),
+            "scale": 0.4,
+            "label_scale": 0.05,
+            "range": (1.0, 40.0),
+            "getter": "get_cam_pan_speed",
+            "setter": "set_cam_pan_speed",
+        },
+        {
+            "type": "slider",
+            "name": "zoom_step",
+            "label": "Zoom step",
+            "pos": (-0.05, 0, -0.35),
+            "label_pos": (-0.55, 0, -0.33),
+            "scale": 0.4,
+            "label_scale": 0.05,
+            "range": (0.1, 5.0),
+            "getter": "get_zoom_step",
+            "setter": "set_zoom_step",
+        },
+    ],
+}
+
+__all__ = ["LAYOUT"]
+

--- a/tests/test_ui_builder.py
+++ b/tests/test_ui_builder.py
@@ -1,0 +1,21 @@
+from runepy.ui.builder import build_ui
+from runepy.ui.debug_layout import LAYOUT
+
+
+def test_build_ui_import():
+    try:
+        widgets = build_ui(None, LAYOUT)
+    except ImportError:  # pragma: no cover - Panda3D missing
+        widgets = build_ui(None, LAYOUT)
+    expected = {
+        'stats',
+        'dump_console',
+        'dump_file',
+        'toggle_pstats',
+        'reload_region',
+        'avatar_speed',
+        'cam_pan_speed',
+        'zoom_step',
+    }
+    assert set(widgets.keys()) == expected
+


### PR DESCRIPTION
## Summary
- add UI builder with Panda3D fallbacks
- describe debug overlay with `LAYOUT`
- generate debug UI using builder
- expose slider helpers in `DebugManager`
- add tests for UI builder
- update changelog

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68588b321468832e9b58a4eae9872e80