### PR TITLE
Add UI editor support

### DIFF
--- a/runepy/debug/gui.py
+++ b/runepy/debug/gui.py
@@ -16,6 +16,12 @@ class DebugWindow(DirectFrame):
     def __init__(self, manager) -> None:
         super().__init__()
         self.widgets = build_ui(self, L, manager)
+        # Keep children clipped inside the window frame
+        if hasattr(self, "setClipFrame") and "frameSize" in self:
+            try:
+                self.setClipFrame(self["frameSize"])
+            except Exception:
+                pass
         self.hide()
 
     # ------------------------------------------------------------------

--- a/runepy/debug/manager.py
+++ b/runepy/debug/manager.py
@@ -214,7 +214,23 @@ class DebugManager:
             base.camera_ctl.set_zoom_step(value)
         except Exception:
             pass
-            pass
+
+    # ------------------------------------------------------------------
+    # UI editor integration
+    # ------------------------------------------------------------------
+    def toggle_ui_editor(self) -> None:
+        if self.window is None:
+            return
+        try:
+            from runepy.ui.editor.controller import UIEditorController
+        except Exception:
+            return
+        if getattr(self, "_ui_editor", None) is None:
+            self._ui_editor = UIEditorController(self.window)
+            self._ui_editor.enable()
+        else:
+            self._ui_editor.disable()
+            self._ui_editor = None
 
     def attach(self, base: Any) -> None:
         """Bind the debug GUI to an existing ShowBase instance.
@@ -235,8 +251,8 @@ class DebugManager:
 
         # 2. Register key events (lower-case names!)
         try:
-            self.base.accept('f1', self.window.toggleVisible)
-            self.base.accept('f1-up', lambda: None)
+            self.base.accept('f1-up', self.window.toggleVisible)
+            self.base.accept('f2', get_debug().toggle_ui_editor)
         except Exception:
             pass
 

--- a/runepy/ui/builder.py
+++ b/runepy/ui/builder.py
@@ -97,6 +97,10 @@ def build_ui(parent: Any, layout: Dict[str, Any], manager: Any | None = None) ->
                 "range",
             }
         }
+        if "pos" in params:
+            params["pos"] = tuple(params["pos"])
+        if "frameSize" in params:
+            params["frameSize"] = tuple(params["frameSize"])
 
         if kind == "button":
             cmd_name = node.get("command")

--- a/runepy/ui/editor/__init__.py
+++ b/runepy/ui/editor/__init__.py
@@ -1,0 +1,7 @@
+"""UI editor package."""
+
+from .controller import UIEditorController
+from .gizmos import SelectionGizmo
+from .serializer import dump_layout
+
+__all__ = ["UIEditorController", "SelectionGizmo", "dump_layout"]

--- a/runepy/ui/editor/gizmos.py
+++ b/runepy/ui/editor/gizmos.py
@@ -1,0 +1,37 @@
+"""UI editor gizmos."""
+from __future__ import annotations
+
+try:
+    from direct.gui.DirectGui import DirectFrame
+except Exception:  # pragma: no cover - Panda3D may be missing
+    DirectFrame = object  # type: ignore
+
+from typing import Any
+
+
+class SelectionGizmo(DirectFrame):
+    """Visual rectangle indicating selected widget."""
+
+    def __init__(self, target: Any) -> None:
+        super().__init__(frameColor=(1, 1, 0, 0.5))
+        self.target = target
+        if hasattr(self, "setBin"):
+            try:
+                self.setBin("fixed", 100)
+            except Exception:
+                pass
+        self.update()
+
+    def update(self) -> None:
+        if not hasattr(self.target, "getPos"):
+            return
+        try:
+            self.reparentTo(self.target.getParent())
+            self.setPos(self.target.getPos())
+            if hasattr(self.target, "__getitem__"):
+                fs = self.target["frameSize"]
+                self["frameSize"] = fs
+        except Exception:
+            pass
+
+__all__ = ["SelectionGizmo"]

--- a/runepy/ui/editor/serializer.py
+++ b/runepy/ui/editor/serializer.py
@@ -1,0 +1,36 @@
+"""Serialize UI layouts to JSON."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+
+def _serialize(node: Any) -> Dict[str, Any]:
+    data: Dict[str, Any] = {}
+    name = getattr(node, "getName", lambda: None)()
+    if name:
+        data["name"] = name
+    if hasattr(node, "getPos"):
+        pos = node.getPos()
+        data["pos"] = [float(pos[0]), float(pos[1]), float(pos[2])]
+    if hasattr(node, "__getitem__"):
+        try:
+            fs = node["frameSize"]
+            data["frameSize"] = [float(v) for v in fs]
+        except Exception:
+            pass
+    children: List[Dict[str, Any]] = []
+    for child in getattr(node, "getChildren", lambda: [])():
+        children.append(_serialize(child))
+    if children:
+        data["children"] = children
+    return data
+
+
+def dump_layout(root_np: Any, path: str | Path) -> None:
+    """Write the layout of ``root_np`` to ``path`` as JSON."""
+    data = _serialize(root_np)
+    Path(path).write_text(json.dumps(data, indent=2))
+
+__all__ = ["dump_layout"]

--- a/tests/test_ui_editor_stub.py
+++ b/tests/test_ui_editor_stub.py
@@ -1,0 +1,10 @@
+import importlib
+
+modules = [
+    'runepy.ui.editor.controller',
+    'runepy.ui.editor.gizmos',
+    'runepy.ui.editor.serializer',
+]
+
+for mod in modules:
+    importlib.import_module(mod)


### PR DESCRIPTION
## Summary
- clip debug overlay frame and toggle on F1 release
- support lists for positions in UI builder
- add UI editor controller, gizmos and serializer modules
- hook up UI editor toggle to F2 key
- ensure imports succeed without Panda3D
- test stub imports

## Testing
- `pip install numpy==1.26.4`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685894145710832e8715371a03592017