### PR TITLE
Add visual cue for UI edit mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ RunePy is a small demonstration project built with [Panda3D](https://www.panda3d
 - Map regions stream in on demand as the player moves
 - F1 debug window with live stats and tweakable sliders
 - Optional UI editor (F2) for rearranging and saving the debug layout
+  (the debug window border turns red while editing)
 
 ## Repository Layout
 

--- a/runepy/ui/editor/controller.py
+++ b/runepy/ui/editor/controller.py
@@ -36,6 +36,7 @@ class UIEditorController:
         self._drag_start = None
         self._widget_start = None
         self._gizmo: SelectionGizmo | None = None
+        self._orig_color = None
 
     # ------------------------------------------------------------------
     def enable(self) -> None:
@@ -49,6 +50,16 @@ class UIEditorController:
         base.accept("mouse1", self._mouse_down)
         base.accept("mouse1-up", self._mouse_up)
         base.taskMgr.add(self._on_mouse_move, "ui-editor-move")
+        if hasattr(self.root, "__setitem__"):
+            try:
+                if hasattr(self.root, "__getitem__"):
+                    try:
+                        self._orig_color = self.root["frameColor"]
+                    except Exception:
+                        self._orig_color = None
+                self.root["frameColor"] = (0.8, 0.0, 0.0, 0.7)
+            except Exception:
+                pass
         if WindowProperties is not object and hasattr(base, "win"):
             try:
                 props = WindowProperties()
@@ -79,6 +90,12 @@ class UIEditorController:
             except Exception:
                 pass
             self._gizmo = None
+        if hasattr(self.root, "__setitem__") and self._orig_color is not None:
+            try:
+                self.root["frameColor"] = self._orig_color
+            except Exception:
+                pass
+            self._orig_color = None
         if WindowProperties is not object and hasattr(base, "win"):
             try:
                 props = WindowProperties()


### PR DESCRIPTION
## Summary
- highlight debug window in UI editor mode
- document UI editor highlight in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c4135c0f4832eb2667859a310289c