### PR TITLE
Prevent game clicks while editing the UI

### DIFF
--- a/runepy/ui/editor/controller.py
+++ b/runepy/ui/editor/controller.py
@@ -37,11 +37,18 @@ class UIEditorController:
         self._widget_start = None
         self._gizmo: SelectionGizmo | None = None
         self._orig_color = None
+        self._orig_click_handler = None
 
     # ------------------------------------------------------------------
     def enable(self) -> None:
         if base is None:
             return
+        if hasattr(base, "tile_click_event"):
+            try:
+                self._orig_click_handler = base.tile_click_event
+                base.ignore("mouse1")
+            except Exception:
+                self._orig_click_handler = None
         base.accept("control-s", self._save)
         base.accept("arrow_up", lambda: self._nudge(0, 0.01))
         base.accept("arrow_down", lambda: self._nudge(0, -0.01))
@@ -83,6 +90,12 @@ class UIEditorController:
             base.ignore(key)
         base.ignore("mouse1")
         base.ignore("mouse1-up")
+        if self._orig_click_handler is not None:
+            try:
+                base.accept("mouse1", self._orig_click_handler)
+            except Exception:
+                pass
+            self._orig_click_handler = None
         base.taskMgr.remove("ui-editor-move")
         if self._gizmo is not None:
             try:

--- a/tests/test_ui_editor_click_override.py
+++ b/tests/test_ui_editor_click_override.py
@@ -1,0 +1,74 @@
+import importlib
+
+modules = [
+    'runepy.ui.editor.controller',
+]
+for m in modules:
+    importlib.import_module(m)
+
+class _FakeMouseWatcher:
+    def hasMouse(self):
+        return True
+    def getMouse(self):
+        return (0, 0)
+    def is_button_down(self, btn):
+        return False
+
+class _FakeTaskMgr:
+    def add(self, func, name):
+        self.added = (func, name)
+    def remove(self, name):
+        self.removed = name
+
+class _FakeBase:
+    def __init__(self):
+        self.mouseWatcherNode = _FakeMouseWatcher()
+        self.taskMgr = _FakeTaskMgr()
+        self.accepted = {}
+    def accept(self, evt, func):
+        self.accepted[evt] = func
+    def ignore(self, evt):
+        self.accepted.pop(evt, None)
+    # game click handler
+    def tile_click_event(self):
+        self.clicked = getattr(self, 'clicked', 0) + 1
+
+class _FakeWidget:
+    def __init__(self, pos=(0,0,0), frame=(-1,1,-1,1)):
+        self._pos = list(pos)
+        self._frame = frame
+        self.children = []
+    def getChildren(self):
+        return self.children
+    def getPos(self):
+        return tuple(self._pos)
+    def setPos(self, x,y,z):
+        self._pos=[x,y,z]
+    def __getitem__(self, k):
+        if k=='frameSize':
+            return self._frame
+        raise KeyError(k)
+    def getPythonTag(self, t):
+        return t == 'debug_gui'
+
+def test_editor_ignores_game_click(monkeypatch):
+    from runepy.ui.editor import controller as ctr
+
+    base = _FakeBase()
+    monkeypatch.setattr(ctr, 'base', base)
+    root = _FakeWidget()
+    editor = ctr.UIEditorController(root)
+
+    base.accept('mouse1', base.tile_click_event)
+    # initial click works
+    base.accepted['mouse1']()
+    assert base.clicked == 1
+
+    editor.enable()
+    base.accepted['mouse1']()
+    # game handler should not fire
+    assert base.clicked == 1
+
+    editor.disable()
+    base.accepted['mouse1']()
+    assert base.clicked == 2


### PR DESCRIPTION
## Summary
- prevent the game's `mouse1` handler from firing when UI editor is enabled
- restore original click handler when editor is disabled
- add regression test for click suppression while editing

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c42639868832eb3fff827c3c17b0e