### PR TITLE
Generate grid around streaming window

### DIFF
--- a/runepy/client.py
+++ b/runepy/client.py
@@ -15,6 +15,7 @@ from runepy.debuginfo import DebugInfo
 from runepy.camera import CameraControl
 from runepy.controls import Controls
 from runepy.world import World
+from constants import REGION_SIZE, VIEW_RADIUS
 from runepy.pathfinding import a_star
 from runepy.collision import CollisionControl
 from runepy.options_menu import KeyBindingManager, OptionsMenu
@@ -42,7 +43,16 @@ class Client(BaseApp):
         self.loading_screen.update(20, "Generating world")
         def world_progress(frac, text):
             self.loading_screen.update(20 + int(30 * frac), text)
-        self.world = World(self.render, debug=self.debug, progress_callback=world_progress)
+
+        view_radius = VIEW_RADIUS
+        world_radius = view_radius * REGION_SIZE
+        self.world = World(
+            self.render,
+            radius=world_radius,
+            debug=self.debug,
+            progress_callback=world_progress,
+            view_radius=view_radius,
+        )
 
         tile_fit_scale = self.world.tile_size * 0.5
         self.loading_screen.update(50, "Loading character")

--- a/runepy/editor_window.py
+++ b/runepy/editor_window.py
@@ -1,5 +1,6 @@
 from runepy.base_app import BaseApp
 from runepy.world import World
+from constants import REGION_SIZE, VIEW_RADIUS
 from runepy.map_editor import MapEditor
 from runepy.camera import FreeCameraControl
 from runepy.options_menu import KeyBindingManager, OptionsMenu
@@ -16,7 +17,9 @@ class EditorWindow(BaseApp):
         super().__init__()
 
     def initialize(self):
-        self.world = World(self.render)
+        view_radius = VIEW_RADIUS
+        world_radius = view_radius * REGION_SIZE
+        self.world = World(self.render, radius=world_radius, view_radius=view_radius)
         self.editor = MapEditor(self, self.world)
         self.editor.save_callback = self.save_map
         self.editor.load_callback = self.load_map

--- a/runepy/world.py
+++ b/runepy/world.py
@@ -84,7 +84,7 @@ class World:
     def __init__(
         self,
         render=None,
-        radius=500,
+        radius=None,
         tile_size=1,
         debug=False,
         map_file=None,
@@ -92,6 +92,8 @@ class World:
         view_radius=1,
     ):
         self.render = render
+        if radius is None:
+            radius = view_radius * REGION_SIZE
         self.radius = radius
         self.tile_size = tile_size
         self.debug = debug


### PR DESCRIPTION
## Summary
- default grid radius is now tied to the streaming window size
- client and editor send `view_radius * REGION_SIZE` when creating the world

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ed9eb8b74832ea2056ea4fb136d4d