### PR TITLE
Add simple UIManager

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ RunePy is a small demonstration project built with [Panda3D](https://www.panda3d
 - Loading screen displays progress messages during startup
 - Map regions stream in on demand as the player moves
 - Placeholder debug window toggled with ``F1``
+- Centralized UI manager for loading and toggling interfaces
 
 ## Repository Layout
 
@@ -33,6 +34,7 @@ RunePy is a small demonstration project built with [Panda3D](https://www.panda3d
 | `runepy/utils.py` | Shared helpers like `get_mouse_tile_coords`. |
 | `runepy/debug/manager.py` | Toggleable debug window and related tools. |
 | `runepy/ui/builder.py` | Constructs GUI widgets from layout dictionaries. |
+| `runepy/ui/manager.py` | Simple manager for loading and showing UIs. |
 | `runepy/ui/editor` | Package providing the simple UI editor. |
 | `runepy/ui_editor.py` | Standalone UI editing window. |
 

--- a/runepy/__init__.py
+++ b/runepy/__init__.py
@@ -4,6 +4,7 @@ from . import pathfinding
 from .array_map import RegionArrays
 from .map_manager import MapManager
 from .terrain import TerrainTile, FLAG_BLOCKED
+from .ui.manager import UIManager
 
 try:
     from .base_app import BaseApp
@@ -17,5 +18,6 @@ __all__ = [
     "MapManager",
     "TerrainTile",
     "FLAG_BLOCKED",
+    "UIManager",
 ]
 

--- a/runepy/ui/manager.py
+++ b/runepy/ui/manager.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+"""Simple UI manager for loading and toggling interface layouts."""
+
+from pathlib import Path
+import importlib
+import json
+from typing import Any, Dict
+
+from .builder import build_ui, StubWidget
+
+try:
+    from direct.gui.DirectGui import DirectFrame
+except Exception:  # pragma: no cover - Panda3D may be missing
+    DirectFrame = StubWidget  # type: ignore
+
+
+class UIManager:
+    """Manage GUI layouts and their root frames."""
+
+    def __init__(self) -> None:
+        self.frames: Dict[str, Any] = {}
+        self.widgets: Dict[str, Dict[str, Any]] = {}
+
+    # ------------------------------------------------------------------
+    def load_ui(self, name: str, layout: str | Dict[str, Any]) -> Any:
+        """Load a UI layout from a module, JSON file or dict."""
+
+        if isinstance(layout, str):
+            path = Path(layout)
+            if path.suffix.lower() == ".json" and path.exists():
+                data = json.loads(path.read_text())
+            else:
+                module = importlib.import_module(layout)
+                if not hasattr(module, "LAYOUT"):
+                    raise ValueError(f"No LAYOUT in {layout}")
+                data = getattr(module, "LAYOUT")
+        else:
+            data = layout
+
+        root = DirectFrame() if DirectFrame is not StubWidget else StubWidget()
+        self.widgets[name] = build_ui(root, data, self)
+        self.frames[name] = root
+        return root
+
+    # ------------------------------------------------------------------
+    def show_ui(self, name: str) -> None:
+        """Display the UI if it was loaded."""
+        frame = self.frames.get(name)
+        if frame is not None and hasattr(frame, "show"):
+            frame.show()
+
+    def hide_ui(self, name: str) -> None:
+        """Hide the UI if it is currently visible."""
+        frame = self.frames.get(name)
+        if frame is not None and hasattr(frame, "hide"):
+            frame.hide()
+
+    def destroy_ui(self, name: str) -> None:
+        """Remove and destroy a loaded UI."""
+        frame = self.frames.pop(name, None)
+        self.widgets.pop(name, None)
+        if frame is not None and hasattr(frame, "destroy"):
+            frame.destroy()
+
+
+__all__ = ["UIManager"]

--- a/tests/test_ui_manager.py
+++ b/tests/test_ui_manager.py
@@ -1,0 +1,11 @@
+from runepy.ui.manager import UIManager
+
+
+def test_manager_load_and_toggle():
+    mgr = UIManager()
+    # layout from existing debug layout module
+    mgr.load_ui("debug", "runepy.ui.debug_layout")
+    assert "debug" in mgr.frames
+    mgr.show_ui("debug")
+    mgr.hide_ui("debug")
+    mgr.destroy_ui("debug")


### PR DESCRIPTION
## Summary
- manage UI layouts with new `UIManager` helper
- export `UIManager` from the package
- document the manager in README
- test basic loading and toggling of UIs

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ef53c5448832ebda3ed8db83e7094