### PR TITLE
Move config module into runepy package

### DIFF
--- a/runepy/client.py
+++ b/runepy/client.py
@@ -21,7 +21,7 @@ from runepy.collision import CollisionControl
 from runepy.options_menu import KeyBindingManager, OptionsMenu
 from runepy.loading_screen import LoadingScreen
 from runepy.debug import get_debug
-from config import load_state, save_state
+from runepy.config import load_state, save_state
 import atexit
 
 

--- a/runepy/config.py
+++ b/runepy/config.py
@@ -1,8 +1,9 @@
 import json
 import os
 
-DEFAULT_CONFIG_PATH = os.path.join(os.path.dirname(__file__), "config.json")
-DEFAULT_STATE_PATH = os.path.join(os.path.dirname(__file__), "state.json")
+_ROOT_DIR = os.path.dirname(os.path.dirname(__file__))
+DEFAULT_CONFIG_PATH = os.path.join(_ROOT_DIR, "config.json")
+DEFAULT_STATE_PATH = os.path.join(_ROOT_DIR, "state.json")
 
 
 def load_config(path: str = DEFAULT_CONFIG_PATH) -> dict:


### PR DESCRIPTION
## Summary
- relocate `config.py` into package
- update imports using the new module path
- adjust default paths to use the project root
- remove old top-level module

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68813acf970c832e9029656df4c45788