### PR TITLE
Add tests for UI controls and editor

### DIFF
--- a/tests/test_controls.py
+++ b/tests/test_controls.py
@@ -1,0 +1,31 @@
+from panda3d.core import NodePath
+from runepy.controls import Controls
+
+class CamControl:
+    def __init__(self, camera):
+        self.camera = camera
+
+
+class FakeBase:
+    def __init__(self, render):
+        self.render = render
+    def accept(self, *a, **k):
+        pass
+
+
+def test_zoom_clamp():
+    render = NodePath('render')
+    cam = NodePath('cam')
+    cam.reparentTo(render)
+    cam.setP(-90)
+    cam.setPos(0, 0, 10)
+
+    base = FakeBase(render)
+    controls = Controls(base, CamControl(cam), None)
+
+    controls.zoom(-1)
+    assert cam.getZ() == 5.0
+
+    cam.setZ(75)
+    controls.zoom(1)
+    assert cam.getZ() == 80.0

--- a/tests/test_keybinding_manager.py
+++ b/tests/test_keybinding_manager.py
@@ -1,0 +1,33 @@
+import types
+from runepy.options_menu import KeyBindingManager
+
+class FakeBase:
+    def __init__(self):
+        self.accepted: list[tuple[str, object]] = []
+        self.ignored: list[str] = []
+
+    def accept(self, evt: str, func):
+        self.accepted.append((evt, func))
+
+    def ignore(self, evt: str):
+        self.ignored.append(evt)
+
+
+def test_bind_and_rebind(monkeypatch):
+    base = FakeBase()
+    mgr = KeyBindingManager(base, {"action": "a"})
+
+    called = []
+    def press():
+        called.append("press")
+    def release():
+        called.append("release")
+
+    mgr.bind("action", press, release)
+    assert ("a", press) in base.accepted
+    assert ("a-up", release) in base.accepted
+
+    mgr.rebind("action", "b")
+    assert "a" in base.ignored and "a-up" in base.ignored
+    assert ("b", press) in base.accepted
+    assert ("b-up", release) in base.accepted

--- a/tests/test_options_menu.py
+++ b/tests/test_options_menu.py
@@ -1,0 +1,62 @@
+import types
+from runepy.options_menu import OptionsMenu, KeyBindingManager
+
+class FakeBase:
+    def __init__(self):
+        self.accepted: list[tuple[str, object]] = []
+        self.ignored: list[str] = []
+
+    def accept(self, evt: str, func):
+        self.accepted.append((evt, func))
+
+    def ignore(self, evt: str):
+        self.ignored.append(evt)
+
+
+class StubFrame:
+    def __init__(self, **kw):
+        self.kw = kw
+        self.destroyed = False
+
+    def destroy(self):
+        self.destroyed = True
+
+
+class StubLabel:
+    def __init__(self, **kw):
+        pass
+
+
+class StubEntry:
+    def __init__(self, initialText='', **kw):
+        self.text = initialText
+
+    def get(self):
+        return self.text
+
+
+class StubButton:
+    def __init__(self, text='', command=None, **kw):
+        self.command = command
+
+
+def test_open_apply_close(monkeypatch):
+    base = FakeBase()
+    mgr = KeyBindingManager(base, {"jump": "space"})
+    menu = OptionsMenu(base, mgr)
+
+    monkeypatch.setattr("runepy.options_menu.DirectFrame", StubFrame)
+    monkeypatch.setattr("runepy.options_menu.DirectLabel", StubLabel)
+    monkeypatch.setattr("runepy.options_menu.DirectEntry", StubEntry)
+    monkeypatch.setattr("runepy.options_menu.DirectButton", StubButton)
+
+    menu.open()
+    assert menu.visible
+    assert isinstance(menu.frame, StubFrame)
+    assert "jump" in menu.entries
+
+    menu.entries["jump"].text = "j"
+    menu.apply()
+    assert mgr.bindings["jump"] == "j"
+    assert not menu.visible
+    assert menu.frame is None

--- a/tests/test_ui_builder_full.py
+++ b/tests/test_ui_builder_full.py
@@ -1,0 +1,59 @@
+from runepy.ui import builder
+
+class FakeWidget:
+    def __init__(self, **kw):
+        self.kw = kw
+    def __getitem__(self, k):
+        return self.kw.get(k)
+    def __setitem__(self, k, v):
+        self.kw[k] = v
+
+FakeFrame = FakeWidget
+FakeButton = FakeWidget
+FakeLabel = FakeWidget
+FakeSlider = FakeWidget
+
+class Manager:
+    def __init__(self):
+        self.clicked = False
+        self.value = None
+    def on_click(self):
+        self.clicked = True
+    def get_val(self):
+        return 0.25
+    def set_val(self, v):
+        self.value = v
+
+
+def test_build_all_widgets(monkeypatch):
+    monkeypatch.setattr(builder, "DirectFrame", FakeFrame)
+    monkeypatch.setattr(builder, "DirectButton", FakeButton)
+    monkeypatch.setattr(builder, "DirectSlider", FakeSlider)
+    monkeypatch.setattr(builder, "DirectLabel", FakeLabel)
+
+    layout = {
+        "type": "frame",
+        "name": "root",
+        "children": [
+            {"type": "label", "name": "lbl", "text": "hi"},
+            {"type": "button", "name": "btn", "command": "on_click"},
+            {
+                "type": "slider",
+                "name": "sld",
+                "getter": "get_val",
+                "setter": "set_val",
+                "range": [0, 1],
+            },
+        ],
+    }
+
+    mgr = Manager()
+    widgets = builder.build_ui(None, layout, mgr)
+    assert set(widgets) == {"root", "lbl", "btn", "sld"}
+
+    widgets["btn"]["command"]()
+    assert mgr.clicked
+
+    widgets["sld"]["value"] = 0.5
+    widgets["sld"]["command"]()
+    assert mgr.value == 0.5

--- a/tests/test_ui_editor_extra.py
+++ b/tests/test_ui_editor_extra.py
@@ -1,0 +1,64 @@
+import importlib
+from pathlib import Path
+
+from runepy.ui.editor import controller as ctr
+
+class FakeWidget:
+    def __init__(self, pos=(0,0,0), frame=(-0.5,0.5,-0.5,0.5)):
+        self._pos = list(pos)
+        self._frame = frame
+    def getPos(self):
+        return tuple(self._pos)
+    def setPos(self, x, y, z):
+        self._pos = [x,y,z]
+    def __getitem__(self, k):
+        if k == "frameSize":
+            return self._frame
+        raise KeyError(k)
+    def getPythonTag(self, tag):
+        return tag == "debug_gui"
+    def getChildren(self):
+        return []
+
+class FakeGizmo:
+    def __init__(self, target):
+        self.target = target
+        self.updated = False
+    def update(self):
+        self.updated = True
+    def destroy(self):
+        self.destroyed = True
+
+class FakeBase:
+    def __init__(self):
+        class _MW:
+            def hasMouse(self):
+                return False
+        self.mouseWatcherNode = _MW()
+        class _TM:
+            def remove(self, name):
+                self.removed = name
+        self.taskMgr = _TM()
+
+
+def test_nudge(monkeypatch):
+    monkeypatch.setattr(ctr, "base", FakeBase())
+    w = FakeWidget()
+    editor = ctr.UIEditorController(FakeWidget())
+    editor._gizmo = FakeGizmo(w)
+    w.setPos(0,0,0)
+    editor._gizmo.target = w
+    editor._nudge(0.1, 0.2)
+    assert w.getPos() == (0.1,0,0.2)
+    assert editor._gizmo.updated
+
+
+def test_save(monkeypatch, tmp_path):
+    saved = {}
+    def fake_dump(root, path):
+        saved['path'] = Path(path)
+    monkeypatch.setattr(ctr, "dump_layout", fake_dump)
+    monkeypatch.setattr(ctr, "base", FakeBase())
+    editor = ctr.UIEditorController(FakeWidget())
+    editor._save()
+    assert saved['path'].name == "debug_layout.json"


### PR DESCRIPTION
## Summary
- add KeyBindingManager tests
- add OptionsMenu tests
- add Controls zoom tests
- add UI builder widget tests
- add extra UI editor tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883f3f846ec832e905c8cf1237949a4