### PR TITLE
Fix packaging for constants module

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,3 +18,6 @@ runepy = "runepy.client:main"
 where = ["."]
 include = ["runepy*"]
 
+[tool.setuptools]
+py-modules = ["constants"]
+


### PR DESCRIPTION
## Summary
- include `constants` module during packaging so runtime imports work

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883f9926d4c832ea98470fb2dc87d6f