### PR TITLE
Fix unused variable in UI editor mouse handler

### DIFF
--- a/runepy/ui/editor/controller.py
+++ b/runepy/ui/editor/controller.py
@@ -121,7 +121,6 @@ class UIEditorController:
     def _on_mouse_move(self, task: "Task"):
         if base is None or not base.mouseWatcherNode.hasMouse():
             return task.cont
-        mpos = base.mouseWatcherNode.getMouse()
         if base.mouseWatcherNode.is_button_down("mouse1") and self._drag_widget:
             return self._update_drag(task)
         return task.cont


### PR DESCRIPTION
## Summary
- remove unused `mpos` retrieval in `_on_mouse_move`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887c7e322ac832eb4029bd6aafd7c2c