### PR TITLE
Update _save signature in UI editor

### DIFF
--- a/runepy/ui/editor/controller.py
+++ b/runepy/ui/editor/controller.py
@@ -217,8 +217,8 @@ class UIEditorController:
         widget.setPos(pos[0] + dx, 0, pos[2] + dz)
         self._gizmo.update()
 
-    def _save(self) -> None:
-        path = Path(__file__).with_name("debug_layout.json")
+    def _save(self, path: str | Path = Path("debug_layout.json")) -> None:
+        path = Path(path)
         try:
             dump_layout(self.root, path)
             print("layout saved")

--- a/tests/test_ui_editor_extra.py
+++ b/tests/test_ui_editor_extra.py
@@ -60,5 +60,6 @@ def test_save(monkeypatch, tmp_path):
     monkeypatch.setattr(ctr, "dump_layout", fake_dump)
     monkeypatch.setattr(ctr, "base", FakeBase())
     editor = ctr.UIEditorController(FakeWidget())
-    editor._save()
-    assert saved['path'].name == "debug_layout.json"
+    out_path = tmp_path / "layout.json"
+    editor._save(out_path)
+    assert saved['path'] == out_path


### PR DESCRIPTION
## Summary
- add optional `path` parameter to `UIEditorController._save`
- adjust test to use new parameter

## Testing
- `pytest tests/test_ui_editor_extra.py::test_save -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887c8ae859c832eb65c9abcb8cfeca1