### PR TITLE
Improve layout save error handling

### DIFF
--- a/runepy/ui_editor.py
+++ b/runepy/ui_editor.py
@@ -35,8 +35,8 @@ class UIEditorApp(ShowBase):
         try:
             dump_layout(get_debug().window, path)  # type: ignore[arg-type]
             print(f"Layout saved to {path}")
-        except Exception:
-            pass
+        except Exception as exc:
+            print(f"Failed to save layout: {exc}")
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- catch exceptions in `save_layout` and print the error

## Testing
- `pip install -q Panda3D==1.10.15 numpy==1.26.4`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887d2b3fbc8832e975e6e2a770cb4c1