### PR TITLE
Add logging configuration and replace prints

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,11 @@ manager.update(70, 20)  # moves into the next region triggering load/unload
 
 
 
+## Logging
+
+Logging is configured automatically when the package is imported.
+Messages are written to `runepy.log` with warnings in `warnings.log` and errors in `errors.log`.
+
 ## Utilities
 
 `utils.py` contains small helper functions used throughout the project. In particular

--- a/runepy/__init__.py
+++ b/runepy/__init__.py
@@ -1,5 +1,7 @@
 """RunePy package."""
 
+from . import logging_config  # noqa: F401
+
 from . import pathfinding
 from .array_map import RegionArrays
 from .map_manager import MapManager

--- a/runepy/character.py
+++ b/runepy/character.py
@@ -1,7 +1,10 @@
 # Character.py
+import logging
 from panda3d.core import Vec3
 from direct.interval.IntervalGlobal import Func, LerpPosInterval, Sequence
 from runepy.world import world_to_region
+
+logger = logging.getLogger(__name__)
 
 
 class Character:
@@ -36,7 +39,7 @@ class Character:
 
     def log(self, *args, **kwargs):
         if self.debug:
-            print(*args, **kwargs)
+            logger.debug(*args, **kwargs)
 
     def move_to(self, target_pos, duration, after_step=None):
         """Create a movement interval toward ``target_pos``

--- a/runepy/client.py
+++ b/runepy/client.py
@@ -1,3 +1,4 @@
+import logging
 from panda3d.core import ModifierButtons, Vec3
 try:
     import direct.showbase.ShowBaseGlobal as sbg
@@ -7,6 +8,8 @@ from runepy.utils import get_mouse_tile_coords, get_tile_from_mouse
 from direct.interval.IntervalGlobal import Sequence, Func
 import math
 import argparse
+
+logger = logging.getLogger(__name__)
 
 from runepy.base_app import BaseApp
 
@@ -99,7 +102,7 @@ class Client(BaseApp):
 
     def log(self, *args, **kwargs):
         if self.debug:
-            print(*args, **kwargs)
+            logger.debug(*args, **kwargs)
 
     def update_tile_hover(self, task):
         mpos, tile_x, tile_y = get_mouse_tile_coords(
@@ -224,14 +227,14 @@ class Client(BaseApp):
     def save_map(self, filename="map.json"):
         """Save the current world grid to ``filename``."""
         self.editor.save_map()
-        print(f"Map saved to {filename}")
+        logger.info(f"Map saved to {filename}")
 
     def load_map(self, filename="map.json"):
         """Load a map from ``filename`` and rebuild the world."""
         self.editor.load_map()
         # World size may change during map load but pathfinding now stitches
         # regions dynamically so no cached grid is needed.
-        print(f"Map loaded from {filename}")
+        logger.info(f"Map loaded from {filename}")
 
     # ------------------------------------------------------------------
     # State persistence

--- a/runepy/debug/manager.py
+++ b/runepy/debug/manager.py
@@ -6,6 +6,8 @@ module is unavailable.
 """
 
 from __future__ import annotations
+import logging
+logger = logging.getLogger(__name__)
 from pathlib import Path
 import datetime
 
@@ -127,7 +129,7 @@ class DebugManager:
 
     def dump_console(self):
         regions, geoms = self._stats()
-        print(
+        logger.info(
             f"{datetime.datetime.now().isoformat()} regions={regions} "
             f"geoms={geoms}"
         )
@@ -242,7 +244,7 @@ class DebugManager:
 
         base.accept('f1', self.window.toggleVisible)
 
-        print('[DebugManager] F1 bound')
+        logger.info('[DebugManager] F1 bound')
 
 
 _debug_instance: Optional[DebugManager] = None

--- a/runepy/editor_window.py
+++ b/runepy/editor_window.py
@@ -1,3 +1,4 @@
+import logging
 from runepy.base_app import BaseApp
 from runepy.world import World
 from constants import REGION_SIZE, VIEW_RADIUS
@@ -7,6 +8,8 @@ from runepy.options_menu import KeyBindingManager, OptionsMenu
 from runepy.controls import Controls
 from runepy.utils import get_mouse_tile_coords
 from runepy.debug import get_debug
+
+logger = logging.getLogger(__name__)
 
 
 
@@ -95,11 +98,11 @@ class EditorWindow(BaseApp):
 
     def save_map(self):
         self.editor.save_map()
-        print("Map saved to map.json")
+        logger.info("Map saved to map.json")
 
     def load_map(self):
         self.editor.load_map()
-        print("Map loaded from map.json")
+        logger.info("Map loaded from map.json")
 
 
 if __name__ == "__main__":

--- a/runepy/logging_config.py
+++ b/runepy/logging_config.py
@@ -1,0 +1,14 @@
+import logging
+
+# Configure loggers
+FORMAT = "%(asctime)s [%(levelname)s] %(name)s: %(message)s"
+handlers = [
+    logging.FileHandler("runepy.log"),
+    logging.FileHandler("warnings.log"),
+]
+error_handler = logging.FileHandler("errors.log")
+error_handler.setLevel(logging.ERROR)
+handlers.append(error_handler)
+
+logging.basicConfig(level=logging.INFO, format=FORMAT, handlers=handlers)
+logging.captureWarnings(True)

--- a/runepy/map_editor.py
+++ b/runepy/map_editor.py
@@ -1,7 +1,10 @@
+import logging
 from runepy.utils import get_tile_from_mouse
 from runepy.world import world_to_region, local_tile
 from runepy.terrain import FLAG_BLOCKED
 from constants import REGION_SIZE
+
+logger = logging.getLogger(__name__)
 
 
 class MapEditor:
@@ -98,9 +101,9 @@ class MapEditor:
         else:
             try:
                 self.save_map()
-                print("Map saved to map.json")
+                logger.info("Map saved to map.json")
             except Exception as exc:
-                print(f"Failed to save map: {exc}")
+                logger.exception("Failed to save map", exc_info=exc)
 
     def _hotkey_load(self):
         if hasattr(self, "load_callback"):
@@ -108,6 +111,6 @@ class MapEditor:
         else:
             try:
                 self.load_map()
-                print("Map loaded from map.json")
+                logger.info("Map loaded from map.json")
             except Exception as exc:
-                print(f"Failed to load map: {exc}")
+                logger.exception("Failed to load map", exc_info=exc)

--- a/runepy/ui/editor/controller.py
+++ b/runepy/ui/editor/controller.py
@@ -1,5 +1,7 @@
 """UI editing controller."""
 from __future__ import annotations
+import logging
+logger = logging.getLogger(__name__)
 
 try:
     from direct.showbase.ShowBaseGlobal import base

--- a/runepy/ui_editor.py
+++ b/runepy/ui_editor.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 """Standalone UI editing application."""
 
 try:
@@ -10,6 +11,8 @@ except Exception:  # pragma: no cover - Panda3D may be missing
 from pathlib import Path
 from runepy.ui.editor import UIEditorController, dump_layout
 from runepy.debug import get_debug
+
+logger = logging.getLogger(__name__)
 
 
 class UIEditorApp(ShowBase):
@@ -34,9 +37,9 @@ class UIEditorApp(ShowBase):
         path = Path("debug_layout.json")
         try:
             dump_layout(get_debug().window, path)  # type: ignore[arg-type]
-            print(f"Layout saved to {path}")
+            logger.info(f"Layout saved to {path}")
         except Exception as exc:
-            print(f"Failed to save layout: {exc}")
+            logger.exception("Failed to save layout", exc_info=exc)
 
 
 def main() -> None:

--- a/runepy/world.py
+++ b/runepy/world.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -10,6 +11,8 @@ import numpy as np
 
 from constants import REGION_SIZE, VIEW_RADIUS
 from runepy.terrain import FLAG_BLOCKED
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -146,7 +149,7 @@ class World:
 
     def log(self, *args, **kwargs):
         if self.debug:
-            print(*args, **kwargs)
+            logger.debug(*args, **kwargs)
 
 
 


### PR DESCRIPTION
## Summary
- add `logging_config` that captures warnings and writes log files
- configure logging when `runepy` package is imported
- switch remaining `print` calls to `logging`
- document how logs are generated

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887d43e30dc832e96f02eaf85ad24a0