### PR TITLE
Fix indentation in client.py

### DIFF
--- a/runepy/client.py
+++ b/runepy/client.py
@@ -187,10 +187,10 @@ class Client(BaseApp):
                         return
 
                     intervals = []
-                      prev_world_x, prev_world_y = (
-                          current_pos.getX(),
-                          current_pos.getY(),
-                      )
+                    prev_world_x, prev_world_y = (
+                        current_pos.getX(),
+                        current_pos.getY(),
+                    )
                     for step in path:
                         world_x = step[0] + off_x
                         world_y = step[1] + off_y
@@ -214,10 +214,10 @@ class Client(BaseApp):
                     self.character.start_sequence(move_sequence)
                     self.log(f"Moved to {(world_x, world_y)}")
 
-                self.log(f"After Update: Camera Hpr: {self.camera.getHpr()}")
-                  self.log(
-                      f"After Update: Character Pos: {self.character.get_position()}"
-                  )
+                    self.log(f"After Update: Camera Hpr: {self.camera.getHpr()}")
+                    self.log(
+                        f"After Update: Character Pos: {self.character.get_position()}"
+                    )
 
         self.collision_control.cleanup()
 


### PR DESCRIPTION
## Summary
- correct inconsistent indentation causing runtime errors
- tidy multi-line logging block

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887d6dbd884832ea018ce810a4e5e13