### PR TITLE
Add DirectEntry support to UI builder

### DIFF
--- a/runepy/ui/builder.py
+++ b/runepy/ui/builder.py
@@ -9,12 +9,14 @@ try:
         DirectButton,
         DirectSlider,
         DirectLabel,
+        DirectEntry,
     )
 except Exception:  # pragma: no cover - Panda3D may be missing
     DirectFrame = None  # type: ignore
     DirectButton = None  # type: ignore
     DirectSlider = None  # type: ignore
     DirectLabel = None  # type: ignore
+    DirectEntry = None  # type: ignore
 
 
 class StubWidget:
@@ -49,6 +51,7 @@ _WIDGETS = {
     "label": DirectLabel or StubWidget,
     "button": DirectButton or StubWidget,
     "slider": DirectSlider or StubWidget,
+    "entry": DirectEntry or StubWidget,
 }
 
 
@@ -168,6 +171,8 @@ def build_ui(
                 if value is not None:
                     params.setdefault("value", value)
                 widget = _make_widget("slider", parent_node, **params)
+        elif kind == "entry":
+            widget = _make_widget("entry", parent_node, **params)
         elif kind == "label":
             widget = _make_widget("label", parent_node, **params)
         elif kind == "frame":

--- a/tests/test_ui_builder_full.py
+++ b/tests/test_ui_builder_full.py
@@ -12,6 +12,7 @@ FakeFrame = FakeWidget
 FakeButton = FakeWidget
 FakeLabel = FakeWidget
 FakeSlider = FakeWidget
+FakeEntry = FakeWidget
 
 class Manager:
     def __init__(self):
@@ -30,6 +31,8 @@ def test_build_all_widgets(monkeypatch):
     monkeypatch.setattr(builder, "DirectButton", FakeButton)
     monkeypatch.setattr(builder, "DirectSlider", FakeSlider)
     monkeypatch.setattr(builder, "DirectLabel", FakeLabel)
+    monkeypatch.setattr(builder, "DirectEntry", FakeEntry)
+    builder._WIDGETS["entry"] = FakeEntry
 
     layout = {
         "type": "frame",
@@ -44,12 +47,15 @@ def test_build_all_widgets(monkeypatch):
                 "setter": "set_val",
                 "range": [0, 1],
             },
+            {"type": "entry", "name": "ent", "initialText": "abc"},
         ],
     }
 
     mgr = Manager()
     widgets = builder.build_ui(None, layout, mgr)
-    assert set(widgets) == {"root", "lbl", "btn", "sld"}
+    assert set(widgets) == {"root", "lbl", "btn", "sld", "ent"}
+    assert isinstance(widgets["ent"], FakeEntry)
+    assert widgets["ent"].kw["initialText"] == "abc"
 
     widgets["btn"]["command"]()
     assert mgr.clicked


### PR DESCRIPTION
## Summary
- support `entry` type widgets in `runepy.ui.builder`
- test UI builder with entry widget

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887d705e33c832e8168e48024063bdd