### PR TITLE
Add editor toolbar

### DIFF
--- a/src/runepy/editor_toolbar.py
+++ b/src/runepy/editor_toolbar.py
@@ -1,0 +1,59 @@
+"""Editor toolbar UI for choosing edit mode and saving/loading."""
+from __future__ import annotations
+
+try:
+    from direct.gui.DirectGui import DirectFrame, DirectOptionMenu, DirectButton
+except Exception:  # pragma: no cover - Panda3D may be missing
+    DirectFrame = object  # type: ignore
+    DirectOptionMenu = object  # type: ignore
+    DirectButton = object  # type: ignore
+
+
+class EditorToolbar:
+    """Top-of-screen toolbar for the map editor."""
+
+    def __init__(self, base, editor) -> None:
+        self.base = base
+        self.editor = editor
+        if DirectFrame is object:
+            self.frame = None
+            return
+        self.frame = DirectFrame(
+            frameColor=(0, 0, 0, 0.7),
+            frameSize=(-1.3, 1.3, -0.05, 0.05),
+            pos=(0, 0, 0.95),
+        )
+        self.mode_menu = DirectOptionMenu(
+            parent=self.frame,
+            items=["Tile", "Interactable"],
+            scale=0.05,
+            initialitem=0,
+            command=self._set_mode,
+            pos=(-1.2, 0, 0),
+        )
+        DirectButton(
+            parent=self.frame,
+            text="Save",
+            scale=0.05,
+            pos=(0.2, 0, 0),
+            command=self.editor.save_map,
+        )
+        DirectButton(
+            parent=self.frame,
+            text="Load",
+            scale=0.05,
+            pos=(0.8, 0, 0),
+            command=self.editor.load_map,
+        )
+
+    # ------------------------------------------------------------------
+    def _set_mode(self, choice: str) -> None:
+        self.editor.set_mode(choice.lower())
+
+    def destroy(self) -> None:
+        if self.frame is not None and hasattr(self.frame, "destroy"):
+            self.frame.destroy()
+            self.frame = None
+
+
+__all__ = ["EditorToolbar"]

--- a/src/runepy/editor_window.py
+++ b/src/runepy/editor_window.py
@@ -3,6 +3,7 @@ from runepy.base_app import BaseApp
 from runepy.world import World
 from constants import REGION_SIZE, VIEW_RADIUS
 from runepy.map_editor import MapEditor
+from runepy.editor_toolbar import EditorToolbar
 from runepy.camera import FreeCameraControl
 from runepy.options_menu import KeyBindingManager, OptionsMenu
 from runepy.controls import Controls
@@ -49,6 +50,8 @@ class EditorWindow(BaseApp):
 
         self.key_manager.bind("open_menu", self.options_menu.toggle)
         self.editor.register_bindings(self.key_manager)
+        self.toolbar = EditorToolbar(self, self.editor)
+        self.accept("mouse1", self.editor.handle_click)
         self.key_manager.bind(
             "move_left",
             lambda: self.camera_control.set_move("left", True),

--- a/src/runepy/map_editor.py
+++ b/src/runepy/map_editor.py
@@ -13,6 +13,7 @@ class MapEditor:
     def __init__(self, client, world):
         self.client = client
         self.world = world
+        self.mode = "tile"
 
     def register_bindings(self, key_manager):
         """Register editor actions with ``key_manager``."""
@@ -20,6 +21,16 @@ class MapEditor:
         key_manager.bind("toggle_interactable", self.toggle_interactable)
         key_manager.bind("save_map", self._hotkey_save)
         key_manager.bind("load_map", self._hotkey_load)
+
+    def set_mode(self, mode: str) -> None:
+        self.mode = mode
+
+    def handle_click(self) -> None:
+        if self.mode == "tile":
+            self.toggle_tile()
+        elif self.mode == "interactable":
+            self.toggle_interactable()
+
 
     def toggle_tile(self):
         if self.client.options_menu.visible:

--- a/tests/test_editor_toolbar.py
+++ b/tests/test_editor_toolbar.py
@@ -1,0 +1,45 @@
+from runepy.editor_toolbar import EditorToolbar
+
+class StubFrame:
+    def __init__(self, **kw):
+        self.kw = kw
+        self.destroyed = False
+    def destroy(self):
+        self.destroyed = True
+
+class StubMenu:
+    def __init__(self, parent=None, items=None, command=None, **kw):
+        self.items = items
+        self.command = command
+        self.kw = kw
+
+class StubButton:
+    def __init__(self, parent=None, text='', command=None, **kw):
+        self.command = command
+        self.kw = kw
+
+class FakeEditor:
+    def __init__(self):
+        self.mode = 'tile'
+        self.saved = False
+        self.loaded = False
+    def set_mode(self, mode):
+        self.mode = mode
+    def save_map(self):
+        self.saved = True
+    def load_map(self):
+        self.loaded = True
+
+class FakeBase:
+    pass
+
+
+def test_toolbar_basic(monkeypatch):
+    monkeypatch.setattr('runepy.editor_toolbar.DirectFrame', StubFrame)
+    monkeypatch.setattr('runepy.editor_toolbar.DirectOptionMenu', StubMenu)
+    monkeypatch.setattr('runepy.editor_toolbar.DirectButton', StubButton)
+
+    editor = FakeEditor()
+    tb = EditorToolbar(FakeBase(), editor)
+    tb._set_mode('Interactable')
+    assert editor.mode == 'interactable'

--- a/tests/test_map_editor.py
+++ b/tests/test_map_editor.py
@@ -58,3 +58,20 @@ def test_save_and_load_map(tmp_path, monkeypatch):
     editor.load_map()
     loaded = world.region_manager.loaded[(0, 0)]
     assert loaded.overlay[1, 1] == 1
+
+def test_handle_click(monkeypatch):
+    world = World(view_radius=1)
+    client = _FakeClient()
+    editor = MapEditor(client, world)
+
+    called = {"tile": 0, "inter": 0}
+    monkeypatch.setattr(editor, "toggle_tile", lambda: called.__setitem__("tile", called["tile"] + 1))
+    monkeypatch.setattr(editor, "toggle_interactable", lambda: called.__setitem__("inter", called["inter"] + 1))
+
+    editor.set_mode("tile")
+    editor.handle_click()
+    assert called["tile"] == 1
+
+    editor.set_mode("interactable")
+    editor.handle_click()
+    assert called["inter"] == 1


### PR DESCRIPTION
## Summary
- support editing mode in `MapEditor`
- show a toolbar in `EditorWindow` with a dropdown and save/load buttons
- add new `EditorToolbar` widget
- test toolbar logic and new editor click handler

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688908386fb8832e9e4f24fde34a4af1