### PR TITLE
Fix tile highlight position

### DIFF
--- a/src/runepy/world.py
+++ b/src/runepy/world.py
@@ -158,7 +158,9 @@ class World:
         coord = (x, y)
         if self._hovered == coord:
             return
-        self.highlight_quad.setPos(x * self.tile_size, y * self.tile_size, 0.05)
+        self.highlight_quad.setPos(
+            (x + 0.5) * self.tile_size, (y + 0.5) * self.tile_size, 0.05
+        )
         self.highlight_quad.show()
         self._hovered = coord
 


### PR DESCRIPTION
## Summary
- adjust highlight overlay to tile center

## Testing
- `python -m py_compile src/runepy/world.py`
- *tests failed*: `pytest -q` (missing dependency: numpy)

------
https://chatgpt.com/codex/tasks/task_e_68890aab1864832e96c06422350386a8