### PR TITLE
Add per-tile textures to Region

### DIFF
--- a/tests/test_region.py
+++ b/tests/test_region.py
@@ -10,6 +10,7 @@ def test_region_edit_round_trip(tmp_path, monkeypatch):
     r.base[1, 1] = 2
     r.overlay[2, 2] = 3
     r.flags[3, 3] = 4
+    r.textures[0, 0, 0, 0] = 128
     r.save()
 
     loaded = Region.load(0, 0)
@@ -17,3 +18,4 @@ def test_region_edit_round_trip(tmp_path, monkeypatch):
     assert np.array_equal(r.base, loaded.base)
     assert np.array_equal(r.overlay, loaded.overlay)
     assert np.array_equal(r.flags, loaded.flags)
+    assert np.array_equal(r.textures, loaded.textures)

--- a/tests/test_region_bin.py
+++ b/tests/test_region_bin.py
@@ -1,3 +1,6 @@
+import gzip
+from pathlib import Path
+
 import numpy as np
 from runepy.world import Region
 from constants import REGION_SIZE
@@ -11,6 +14,7 @@ def test_region_round_trip(tmp_path, monkeypatch):
     r1.base[2, 2] = 3
     r1.overlay[3, 3] = 4
     r1.flags[4, 4] = 7
+    r1.textures[5, 5, 0, 0] = 255
     r1.save()
 
     r2 = Region.load(0, 0)
@@ -18,3 +22,28 @@ def test_region_round_trip(tmp_path, monkeypatch):
     assert np.array_equal(r1.base, r2.base)
     assert np.array_equal(r1.overlay, r2.overlay)
     assert np.array_equal(r1.flags, r2.flags)
+    assert np.array_equal(r1.textures, r2.textures)
+
+
+def test_region_load_v1(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    path = Path("maps") / "region_0_0.bin"
+    path.parent.mkdir(parents=True)
+
+    size = REGION_SIZE * REGION_SIZE
+    height = np.zeros((REGION_SIZE, REGION_SIZE), dtype=np.int16)
+    base = np.zeros((REGION_SIZE, REGION_SIZE), dtype=np.uint8)
+    overlay = np.zeros((REGION_SIZE, REGION_SIZE), dtype=np.uint8)
+    flags = np.zeros((REGION_SIZE, REGION_SIZE), dtype=np.uint8)
+    height[1, 1] = 1
+    with gzip.open(path, "wb") as f:
+        f.write((1).to_bytes(2, "little"))
+        f.write(height.tobytes())
+        f.write(base.tobytes())
+        f.write(overlay.tobytes())
+        f.write(flags.tobytes())
+
+    loaded = Region.load(0, 0)
+    assert loaded.height[1, 1] == 1
+    assert loaded.textures.shape == (REGION_SIZE, REGION_SIZE, 16, 16)
+    assert np.all(loaded.textures == 0)


### PR DESCRIPTION
## Summary
- extend `Region` to keep a 16×16 texture per tile
- write/read these textures to the region binary files
- preserve ability to load old v1 region data
- test saving/loading with textures and backward compatibility

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68891040b3e4832eb127d513fd541665