### PR TITLE
Add texture editor tool window

### DIFF
--- a/src/runepy/editor_toolbar.py
+++ b/src/runepy/editor_toolbar.py
@@ -40,6 +40,13 @@ class EditorToolbar:
         )
         DirectButton(
             parent=self.frame,
+            text="Texture",
+            scale=0.05,
+            pos=(0.5, 0, 0),
+            command=self.editor.open_texture_editor,
+        )
+        DirectButton(
+            parent=self.frame,
             text="Load",
             scale=0.05,
             pos=(0.8, 0, 0),

--- a/src/runepy/map_editor.py
+++ b/src/runepy/map_editor.py
@@ -3,6 +3,7 @@ from runepy.utils import get_tile_from_mouse
 from runepy.world import world_to_region, local_tile
 from runepy.terrain import FLAG_BLOCKED
 from constants import REGION_SIZE
+from runepy.texture_editor import TextureEditor
 
 logger = logging.getLogger(__name__)
 
@@ -14,6 +15,7 @@ class MapEditor:
         self.client = client
         self.world = world
         self.mode = "tile"
+        self.texture_editor = TextureEditor(client, world)
 
     def register_bindings(self, key_manager):
         """Register editor actions with ``key_manager``."""
@@ -89,6 +91,18 @@ class MapEditor:
                 region.ry * REGION_SIZE,
                 0,
             )
+    def open_texture_editor(self):
+        if self.client.options_menu.visible:
+            return
+        tile_x, tile_y = get_tile_from_mouse(
+            self.client.mouseWatcherNode,
+            self.client.camera,
+            self.client.render,
+        )
+        if tile_x is None:
+            return
+        self.texture_editor.open(tile_x, tile_y)
+
 
     # ------------------------------------------------------------------
     # Persistence helpers

--- a/src/runepy/texture_editor.py
+++ b/src/runepy/texture_editor.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+"""Simple per-tile texture editor."""
+
+try:
+    from direct.gui.DirectGui import DirectFrame, DirectButton
+except Exception:  # pragma: no cover - Panda3D may be missing
+    DirectFrame = object  # type: ignore
+    DirectButton = object  # type: ignore
+
+from typing import Any
+
+from constants import REGION_SIZE
+from runepy.world import world_to_region, local_tile
+
+
+class TextureEditor:
+    """Lightweight tool for editing per-tile textures."""
+
+    def __init__(self, base: Any, world) -> None:
+        self.base = base
+        self.world = world
+        self.frame = None
+        self.selected_color = 0
+        self.region = None
+        self.lx = None
+        self.ly = None
+        if DirectFrame is not object:
+            self.frame = DirectFrame(
+                frameColor=(0, 0, 0, 0.7),
+                frameSize=(-0.6, 0.6, -0.6, 0.6),
+                pos=(0, 0, 0.2),
+            )
+            self.frame.hide()
+            palette = [0, 64, 128, 192, 255]
+            step = 0.24
+            for i, val in enumerate(palette):
+                btn = DirectButton(
+                    parent=self.frame,
+                    text=str(val),
+                    scale=0.05,
+                    pos=(-0.55 + i * step, 0, 0.45),
+                    command=lambda v=val: self.set_color(v),
+                )
+                btn['text_fg'] = (val / 255.0,) * 3 + (1,)
+            # 16x16 grid of buttons for painting
+            self._grid_buttons = []
+            gstep = 0.07
+            start = -0.5
+            for y in range(16):
+                row = []
+                for x in range(16):
+                    btn = DirectButton(
+                        parent=self.frame,
+                        text="",
+                        scale=0.03,
+                        pos=(start + x * gstep, 0, 0.35 - y * gstep),
+                        command=lambda xx=x, yy=y: self.paint(xx, yy),
+                    )
+                    row.append(btn)
+                self._grid_buttons.append(row)
+        else:  # pragma: no cover - tests
+            self._grid_buttons = [[None for _ in range(16)] for _ in range(16)]
+
+    # ------------------------------------------------------------------
+    def open(self, tile_x: int, tile_y: int) -> None:
+        """Open the editor for the given tile."""
+        rx, ry = world_to_region(tile_x, tile_y)
+        region = self.world.region_manager.loaded.get((rx, ry))
+        if region is None:
+            self.world.region_manager.ensure(tile_x, tile_y)
+            region = self.world.region_manager.loaded.get((rx, ry))
+            if region is None:
+                return
+        lx, ly = local_tile(tile_x, tile_y)
+        self.region = region
+        self.lx = lx
+        self.ly = ly
+        if self.frame is not None:
+            for y in range(16):
+                for x in range(16):
+                    val = int(region.textures[ly, lx, y, x])
+                    btn = self._grid_buttons[y][x]
+                    if btn is not None and hasattr(btn, '__setitem__'):
+                        btn['text'] = ''
+                        btn['frameColor'] = (val / 255.0,) * 3 + (1,)
+            self.frame.show()
+
+    def close(self) -> None:
+        if self.frame is not None:
+            self.frame.hide()
+        self.region = None
+        self.lx = None
+        self.ly = None
+
+    # ------------------------------------------------------------------
+    def set_color(self, val: int) -> None:
+        self.selected_color = max(0, min(255, int(val)))
+
+    def paint(self, px: int, py: int) -> None:
+        if self.region is None:
+            return
+        self.region.textures[self.ly, self.lx, py, px] = self.selected_color
+        if self.frame is not None:
+            btn = self._grid_buttons[py][px]
+            if btn is not None and hasattr(btn, '__setitem__'):
+                btn['frameColor'] = (self.selected_color / 255.0,) * 3 + (1,)
+        self.region.make_mesh()
+        if self.region.node is not None and hasattr(self.base, 'render'):
+            parent = getattr(self.base, 'tile_root', self.base.render)
+            self.region.node.reparentTo(parent)
+            self.region.node.setPos(
+                self.region.rx * REGION_SIZE,
+                self.region.ry * REGION_SIZE,
+                0,
+            )

--- a/tests/test_editor_toolbar.py
+++ b/tests/test_editor_toolbar.py
@@ -29,6 +29,8 @@ class FakeEditor:
         self.saved = True
     def load_map(self):
         self.loaded = True
+    def open_texture_editor(self):
+        pass
 
 class FakeBase:
     pass

--- a/tests/test_texture_editor.py
+++ b/tests/test_texture_editor.py
@@ -1,0 +1,42 @@
+import types
+from runepy.world import World
+from runepy.map_editor import MapEditor
+
+class StubFrame:
+    def __init__(self, **kw):
+        self.kw = kw
+    def hide(self):
+        self.hidden = True
+    def show(self):
+        self.hidden = False
+
+class StubButton:
+    def __init__(self, parent=None, text="", scale=0.0, pos=(0,0,0), command=None):
+        self.command = command
+    def __setitem__(self, key, val):
+        pass
+
+class _FakeClient:
+    def __init__(self):
+        from panda3d.core import NodePath
+        self.options_menu = types.SimpleNamespace(visible=False)
+        self.mouseWatcherNode = None
+        self.camera = None
+        self.render = NodePath('render')
+        self.tile_root = NodePath('tile_root')
+
+
+def test_texture_paint(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr('runepy.texture_editor.DirectFrame', StubFrame)
+    monkeypatch.setattr('runepy.texture_editor.DirectButton', StubButton)
+    world = World(view_radius=1)
+    client = _FakeClient()
+    editor = MapEditor(client, world)
+    monkeypatch.setattr('runepy.map_editor.get_tile_from_mouse', lambda *a: (0, 0))
+
+    editor.open_texture_editor()
+    editor.texture_editor.set_color(123)
+    editor.texture_editor.paint(5, 6)
+    region = world.region_manager.loaded[(0,0)]
+    assert region.textures[0, 0, 6, 5] == 123


### PR DESCRIPTION
## Summary
- add a `TextureEditor` window to paint per-tile textures
- expose the texture editor from `MapEditor`
- add a toolbar button to launch the editor
- test that painting modifies stored texture data

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889113adb6c832e985a33fd93276853