### PR TITLE
Handle base click override in texture editor

### DIFF
--- a/src/runepy/texture_editor.py
+++ b/src/runepy/texture_editor.py
@@ -25,6 +25,7 @@ class TextureEditor:
         self.region = None
         self.lx = None
         self.ly = None
+        self._orig_click_handler = None
         if DirectFrame is not object:
             self.frame = DirectFrame(
                 frameColor=(0, 0, 0, 0.7),
@@ -65,6 +66,12 @@ class TextureEditor:
     # ------------------------------------------------------------------
     def open(self, tile_x: int, tile_y: int) -> None:
         """Open the editor for the given tile."""
+        if hasattr(self.base, "tile_click_event"):
+            try:
+                self._orig_click_handler = self.base.tile_click_event
+                self.base.ignore("mouse1")
+            except Exception:
+                self._orig_click_handler = None
         rx, ry = world_to_region(tile_x, tile_y)
         region = self.world.region_manager.loaded.get((rx, ry))
         if region is None:
@@ -89,6 +96,12 @@ class TextureEditor:
     def close(self) -> None:
         if self.frame is not None:
             self.frame.hide()
+        if self._orig_click_handler is not None:
+            try:
+                self.base.accept("mouse1", self._orig_click_handler)
+            except Exception:
+                pass
+            self._orig_click_handler = None
         self.region = None
         self.lx = None
         self.ly = None

--- a/tests/test_texture_editor_click_override.py
+++ b/tests/test_texture_editor_click_override.py
@@ -1,0 +1,33 @@
+import types
+from runepy.world import World
+from runepy.texture_editor import TextureEditor
+
+class _FakeBase:
+    def __init__(self):
+        self.accepted = {}
+    def accept(self, evt, func):
+        self.accepted[evt] = func
+    def ignore(self, evt):
+        self.accepted.pop(evt, None)
+    def tile_click_event(self):
+        self.clicked = getattr(self, 'clicked', 0) + 1
+
+
+def test_texture_editor_ignores_game_click(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    base = _FakeBase()
+    world = World(view_radius=1)
+    editor = TextureEditor(base, world)
+
+    base.accept('mouse1', base.tile_click_event)
+    base.accepted['mouse1']()
+    assert base.clicked == 1
+
+    editor.open(0, 0)
+    if 'mouse1' in base.accepted:
+        base.accepted['mouse1']()
+    assert base.clicked == 1
+
+    editor.close()
+    base.accepted['mouse1']()
+    assert base.clicked == 2


### PR DESCRIPTION
## Summary
- ignore existing base click handler when opening `TextureEditor`
- restore the original handler on close
- add regression test for click override

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68891a3f47cc832e9380bdebed986707