### PR TITLE
Improve texture palette buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ RunePy is a small demonstration project built with [Panda3D](https://www.panda3d
 - Debug overlay displaying tile information
 - Simple collision and ray casting
 - Camera zoom limits keep the view between a minimum and maximum height
-- Built-in map editor with hotkeys for saving and loading maps
+- Built-in map editor with hotkeys for saving and loading maps and a color palette for painting tiles
 - Tiles support custom metadata loaded from map files
 - Individual tiles darken slightly when hovered to show the current mouse position
 - Loading screen displays progress messages during startup
@@ -77,6 +77,9 @@ To launch the map editor instead of the game, run:
 ```bash
 runepy --mode editor
 ```
+
+The editor toolbar includes a **Texture** button that opens a simple painting tool.
+Use the palette buttons at the top to select a color and click the grid to apply it to tiles.
 
 To open the standalone UI editor, run:
 

--- a/src/runepy/texture_editor.py
+++ b/src/runepy/texture_editor.py
@@ -37,12 +37,12 @@ class TextureEditor:
             for i, val in enumerate(palette):
                 btn = DirectButton(
                     parent=self.frame,
-                    text=str(val),
+                    text="",
+                    frameColor=(val/255.0, val/255.0, val/255.0, 1),
                     scale=0.05,
                     pos=(-0.55 + i * step, 0, 0.45),
                     command=lambda v=val: self.set_color(v),
                 )
-                btn['text_fg'] = (val / 255.0,) * 3 + (1,)
             # 16x16 grid of buttons for painting
             self._grid_buttons = []
             gstep = 0.07

--- a/tests/test_texture_editor.py
+++ b/tests/test_texture_editor.py
@@ -11,7 +11,7 @@ class StubFrame:
         self.hidden = False
 
 class StubButton:
-    def __init__(self, parent=None, text="", scale=0.0, pos=(0,0,0), command=None):
+    def __init__(self, parent=None, text="", scale=0.0, pos=(0,0,0), command=None, **kw):
         self.command = command
     def __setitem__(self, key, val):
         pass


### PR DESCRIPTION
## Summary
- show palette colors directly on buttons by setting frameColor
- allow palette-related keyword arguments in texture editor test stub
- mention palette in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68891a4658a4832eadcc031e89af23b4