### PR TITLE
Improve texture editor docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,17 @@ runepy --mode editor
 ```
 
 The editor toolbar includes a **Texture** button that opens a simple painting tool.
+The main area of this window is a 16×16 grid of texture cells. Each cell represents a
+layer of the selected tile that can be painted individually. A simplified view of the
+layout looks like:
+
+```
+[0,0] [1,0] ... [15,0]
+[0,1] [1,1] ... [15,1]
+  ...
+[0,15] ... [15,15]
+```
+
 Use the palette buttons at the top to select a color and click the grid to apply it to tiles.
 
 To open the standalone UI editor, run:


### PR DESCRIPTION
## Summary
- document that the texture editor uses a 16x16 grid of cells
- include a small diagram showing the cell layout

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688921134544832e89728fca55dfbb6b