### PR TITLE
Add texture editor toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ runepy --mode editor
 
 The editor toolbar includes a **Texture** button that opens a simple painting tool.
 Use the palette buttons at the top to select a color and click the grid to apply it to tiles.
+Click the button again or press **Close** in the editor to hide the texture window.
 
 To open the standalone UI editor, run:
 

--- a/src/runepy/map_editor.py
+++ b/src/runepy/map_editor.py
@@ -94,6 +94,9 @@ class MapEditor:
     def open_texture_editor(self):
         if self.client.options_menu.visible:
             return
+        if self.texture_editor.region is not None:
+            self.texture_editor.close()
+            return
         tile_x, tile_y = get_tile_from_mouse(
             self.client.mouseWatcherNode,
             self.client.camera,

--- a/src/runepy/texture_editor.py
+++ b/src/runepy/texture_editor.py
@@ -60,6 +60,14 @@ class TextureEditor:
                     )
                     row.append(btn)
                 self._grid_buttons.append(row)
+            # optional close button
+            DirectButton(
+                parent=self.frame,
+                text="Close",
+                scale=0.05,
+                pos=(0, 0, -0.55),
+                command=self.close,
+            )
         else:  # pragma: no cover - tests
             self._grid_buttons = [[None for _ in range(16)] for _ in range(16)]
 


### PR DESCRIPTION
## Summary
- allow closing the texture editor from the toolbar
- add a "Close" button to the texture editor window
- document how to close the texture editor

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688922e918c4832e8def3b9549e7ad01