### PR TITLE
Improve texture editor focus handling

### DIFF
--- a/src/runepy/client.py
+++ b/src/runepy/client.py
@@ -87,7 +87,11 @@ class Client(BaseApp):
         self.options_menu = OptionsMenu(self, self.key_manager)
         self.key_manager.bind("open_menu", self.options_menu.toggle)
 
-        self.accept("mouse1", self.tile_click_event)
+        # Store the bound click handler so it can be reliably removed by
+        # other tools (like the texture editor) without relying on the
+        # ephemeral bound method object returned by attribute access.
+        self.tile_click_event_ref = self.tile_click_event
+        self.accept("mouse1", self.tile_click_event_ref)
         self.accept("f3", self.debug_info.toggle_region_info)
 
         self.loading_screen.update(80, "Finalizing")

--- a/src/runepy/texture_editor.py
+++ b/src/runepy/texture_editor.py
@@ -74,10 +74,13 @@ class TextureEditor:
     # ------------------------------------------------------------------
     def open(self, tile_x: int, tile_y: int) -> None:
         """Open the editor for the given tile."""
-        if hasattr(self.base, "tile_click_event"):
+        if hasattr(self.base, "tile_click_event") or hasattr(self.base, "tile_click_event_ref"):
             try:
-                self._orig_click_handler = self.base.tile_click_event
-                self.base.ignore("mouse1", self._orig_click_handler)
+                handler = getattr(self.base, "tile_click_event_ref", None)
+                if handler is None:
+                    handler = self.base.tile_click_event
+                self._orig_click_handler = handler
+                self.base.ignore("mouse1", handler)
             except Exception:
                 self._orig_click_handler = None
         rx, ry = world_to_region(tile_x, tile_y)

--- a/tests/test_texture_editor_method_handler.py
+++ b/tests/test_texture_editor_method_handler.py
@@ -1,0 +1,38 @@
+import types
+from runepy.world import World
+from runepy.texture_editor import TextureEditor
+
+class _MethodBase:
+    def __init__(self):
+        self.accepted = {}
+    def tile_click_event(self):
+        self.clicked = getattr(self, 'clicked', 0) + 1
+    def accept(self, evt, func):
+        self.accepted[evt] = func
+    def ignore(self, evt, func=None):
+        if func is None:
+            self.accepted.pop(evt, None)
+        else:
+            if evt in self.accepted and self.accepted[evt] is func:
+                self.accepted.pop(evt)
+
+
+def test_texture_editor_with_method_handler(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    base = _MethodBase()
+    base.tile_click_event_ref = base.tile_click_event
+    world = World(view_radius=1)
+    editor = TextureEditor(base, world)
+
+    base.accept('mouse1', base.tile_click_event_ref)
+    base.accepted['mouse1']()
+    assert base.clicked == 1
+
+    editor.open(0, 0)
+    if 'mouse1' in base.accepted:
+        base.accepted['mouse1']()
+    assert base.clicked == 1
+
+    editor.close()
+    base.accepted['mouse1']()
+    assert base.clicked == 2


### PR DESCRIPTION
## Summary
- store a stable reference to the game click handler
- respect the stored handler when the texture editor disables clicks
- add regression test covering method-based handlers

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6889254c6038832e904226eada1e6137