### PR TITLE
Improve texture editor focus handling

### DIFF
--- a/src/runepy/client.py
+++ b/src/runepy/client.py
@@ -87,7 +87,11 @@ class Client(BaseApp):
         self.options_menu = OptionsMenu(self, self.key_manager)
         self.key_manager.bind("open_menu", self.options_menu.toggle)
 
-        self.accept("mouse1", self.tile_click_event)
+        # Store the bound click handler so it can be reliably removed by
+        # other tools (like the texture editor) without relying on the
+        # ephemeral bound method object returned by attribute access.
+        self.tile_click_event_ref = self.tile_click_event
+        self.accept("mouse1", self.tile_click_event_ref)
         self.accept("f3", self.debug_info.toggle_region_info)
 
         self.loading_screen.update(80, "Finalizing")

--- a/src/runepy/editor_window.py
+++ b/src/runepy/editor_window.py
@@ -51,8 +51,10 @@ class EditorWindow(BaseApp):
         self.key_manager.bind("open_menu", self.options_menu.toggle)
         self.editor.register_bindings(self.key_manager)
         self.toolbar = EditorToolbar(self, self.editor)
-        self.tile_click_event = self.editor.handle_click
-        self.accept("mouse1", self.tile_click_event)
+        # Store the bound click handler so the texture editor can reliably
+        # remove it without depending on ephemeral bound method objects.
+        self.tile_click_event_ref = self.editor.handle_click
+        self.accept("mouse1", self.tile_click_event_ref)
         self.key_manager.bind(
             "move_left",
             lambda: self.camera_control.set_move("left", True),

--- a/src/runepy/texture_editor.py
+++ b/src/runepy/texture_editor.py
@@ -74,10 +74,13 @@ class TextureEditor:
     # ------------------------------------------------------------------
     def open(self, tile_x: int, tile_y: int) -> None:
         """Open the editor for the given tile."""
-        if hasattr(self.base, "tile_click_event"):
+        if hasattr(self.base, "tile_click_event") or hasattr(self.base, "tile_click_event_ref"):
             try:
-                self._orig_click_handler = self.base.tile_click_event
-                self.base.ignore("mouse1", self._orig_click_handler)
+                handler = getattr(self.base, "tile_click_event_ref", None)
+                if handler is None:
+                    handler = self.base.tile_click_event
+                self._orig_click_handler = handler
+                self.base.ignore("mouse1", handler)
             except Exception:
                 self._orig_click_handler = None
         rx, ry = world_to_region(tile_x, tile_y)

--- a/tests/test_editor_window_method_handler.py
+++ b/tests/test_editor_window_method_handler.py
@@ -1,0 +1,92 @@
+import types
+from runepy.texture_editor import TextureEditor
+from panda3d.core import NodePath
+
+class _MethodBase:
+    def __init__(self):
+        self.accepted = {}
+        self.render = NodePath('render')
+        self.camera = NodePath('camera')
+        self.taskMgr = types.SimpleNamespace(add=lambda *a, **k: None)
+        self.mouseWatcherNode = None
+    def tile_click_event(self):
+        self.clicked = getattr(self, 'clicked', 0) + 1
+    def accept(self, evt, func):
+        self.accepted[evt] = func
+    def ignore(self, evt, func=None):
+        if func is None:
+            self.accepted.pop(evt, None)
+        else:
+            if evt in self.accepted and self.accepted[evt] is func:
+                self.accepted.pop(evt)
+    def disableMouse(self):
+        pass
+    def setBackgroundColor(self, *a, **k):
+        pass
+
+class _FakeMapEditor:
+    def __init__(self, client, world):
+        self.client = client
+        self.world = world
+        self.texture_editor = TextureEditor(client, world)
+    def register_bindings(self, mgr):
+        pass
+    def handle_click(self):
+        self.client.clicked = getattr(self.client, 'clicked', 0) + 1
+
+class _FakeCamera:
+    def __init__(self, *a, **k):
+        pass
+    def start(self, base):
+        pass
+    def set_move(self, *a, **k):
+        pass
+
+class _FakeControls:
+    def __init__(self, *a, **k):
+        pass
+
+class _FakeKeyManager:
+    def __init__(self, *a, **k):
+        pass
+    def bind(self, *a, **k):
+        pass
+
+class _FakeOptionsMenu:
+    def __init__(self, *a, **k):
+        self.visible = False
+    def toggle(self):
+        self.visible = not self.visible
+
+class _FakeToolbar:
+    def __init__(self, *a, **k):
+        pass
+
+
+def test_editor_window_method_handler(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr("runepy.base_app.BaseApp", _MethodBase)
+    monkeypatch.setattr('runepy.editor_window.BaseApp', _MethodBase)
+    monkeypatch.setattr('runepy.editor_window.MapEditor', _FakeMapEditor)
+    monkeypatch.setattr('runepy.editor_window.FreeCameraControl', _FakeCamera)
+    monkeypatch.setattr('runepy.editor_window.Controls', _FakeControls)
+    monkeypatch.setattr('runepy.editor_window.KeyBindingManager', _FakeKeyManager)
+    monkeypatch.setattr('runepy.editor_window.OptionsMenu', _FakeOptionsMenu)
+    monkeypatch.setattr('runepy.editor_window.EditorToolbar', _FakeToolbar)
+
+    from runepy.editor_window import EditorWindow
+
+    app = EditorWindow()
+    app.initialize()
+
+    app.accepted['mouse1']()
+    assert app.clicked == 1
+
+    app.editor.texture_editor.open(0, 0)
+    if 'mouse1' in app.accepted:
+        app.accepted['mouse1']()
+    assert app.clicked == 1
+
+    app.editor.texture_editor.close()
+    app.accepted['mouse1']()
+    assert app.clicked == 2

--- a/tests/test_texture_editor_method_handler.py
+++ b/tests/test_texture_editor_method_handler.py
@@ -1,0 +1,38 @@
+import types
+from runepy.world import World
+from runepy.texture_editor import TextureEditor
+
+class _MethodBase:
+    def __init__(self):
+        self.accepted = {}
+    def tile_click_event(self):
+        self.clicked = getattr(self, 'clicked', 0) + 1
+    def accept(self, evt, func):
+        self.accepted[evt] = func
+    def ignore(self, evt, func=None):
+        if func is None:
+            self.accepted.pop(evt, None)
+        else:
+            if evt in self.accepted and self.accepted[evt] is func:
+                self.accepted.pop(evt)
+
+
+def test_texture_editor_with_method_handler(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    base = _MethodBase()
+    base.tile_click_event_ref = base.tile_click_event
+    world = World(view_radius=1)
+    editor = TextureEditor(base, world)
+
+    base.accept('mouse1', base.tile_click_event_ref)
+    base.accepted['mouse1']()
+    assert base.clicked == 1
+
+    editor.open(0, 0)
+    if 'mouse1' in base.accepted:
+        base.accepted['mouse1']()
+    assert base.clicked == 1
+
+    editor.close()
+    base.accepted['mouse1']()
+    assert base.clicked == 2


### PR DESCRIPTION
## Summary
- store a stable reference to the game click handler
- respect the stored handler when the texture editor disables clicks
- store a stable click handler for the editor window too
- add regression tests for method-based handlers

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889254c6038832e904226eada1e6137