### PR TITLE
Fix debug window capturing clicks

### DIFF
--- a/src/runepy/debug/gui.py
+++ b/src/runepy/debug/gui.py
@@ -15,7 +15,9 @@ from runepy.ui.debug_layout import LAYOUT as L
 class DebugWindow(DirectFrame):
     def __init__(self, manager) -> None:
         super().__init__()
+        self.manager = manager
         self.widgets = build_ui(self, L, manager)
+        self._orig_click_handler = None
         # Keep children clipped inside the window frame
         if hasattr(self, "setClipFrame") and "frameSize" in self:
             try:
@@ -28,8 +30,34 @@ class DebugWindow(DirectFrame):
     def toggleVisible(self):
         if self.isHidden():
             self.show()
+            self._suspend_click()
         else:
             self.hide()
+            self._restore_click()
+
+    def _suspend_click(self) -> None:
+        base = getattr(self.manager, "base", None)
+        handler = None
+        if base is not None:
+            handler = getattr(base, "tile_click_event_ref", None)
+            if handler is None:
+                handler = getattr(base, "tile_click_event", None)
+            if handler is not None:
+                try:
+                    base.ignore("mouse1", handler)
+                except Exception:
+                    handler = None
+        self._orig_click_handler = handler
+
+    def _restore_click(self) -> None:
+        base = getattr(self.manager, "base", None)
+        handler = self._orig_click_handler
+        if base is not None and handler is not None:
+            try:
+                base.accept("mouse1", handler)
+            except Exception:
+                pass
+        self._orig_click_handler = None
 
     def refresh_task(self, task: "Task"):
         if "stats" not in self.widgets:

--- a/tests/test_debug_window_click_override.py
+++ b/tests/test_debug_window_click_override.py
@@ -1,0 +1,50 @@
+class FakeBase:
+    def __init__(self):
+        self.accepted = {}
+        def click():
+            self.clicked = getattr(self, 'clicked', 0) + 1
+        self.tile_click_event = click
+    def accept(self, evt, func):
+        self.accepted[evt] = func
+    def ignore(self, evt, func=None):
+        if func is None:
+            self.accepted.pop(evt, None)
+        else:
+            if evt in self.accepted and self.accepted[evt] is func:
+                self.accepted.pop(evt)
+
+class StubFrame:
+    def __init__(self, *a, **k):
+        self.hidden = True
+    def show(self):
+        self.hidden = False
+    def hide(self):
+        self.hidden = True
+    def isHidden(self):
+        return self.hidden
+    def setClipFrame(self, *a, **k):
+        pass
+
+def test_debug_window_click_override(monkeypatch):
+    import runepy.debug.gui as gui
+    from runepy.debug import get_debug
+
+    monkeypatch.setattr(gui, 'DirectFrame', StubFrame)
+    monkeypatch.setattr(gui, 'build_ui', lambda *a, **k: {})
+
+    dbg = get_debug()
+    base = FakeBase()
+    dbg.attach(base)
+
+    base.accept('mouse1', base.tile_click_event)
+    base.accepted['mouse1']()
+    assert base.clicked == 1
+
+    dbg.window.toggleVisible()
+    if 'mouse1' in base.accepted:
+        base.accepted['mouse1']()
+    assert base.clicked == 1
+
+    dbg.window.toggleVisible()
+    base.accepted['mouse1']()
+    assert base.clicked == 2


### PR DESCRIPTION
## Summary
- prevent game input when debug window is visible
- test click suppression for debug window

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688929788878832e935440c52c70d3f4