### PR TITLE
Refactor GUI layout creation

### DIFF
--- a/src/runepy/editor_toolbar.py
+++ b/src/runepy/editor_toolbar.py
@@ -7,6 +7,8 @@ except Exception:  # pragma: no cover - Panda3D may be missing
     DirectFrame = object  # type: ignore
     DirectOptionMenu = object  # type: ignore
     DirectButton = object  # type: ignore
+from runepy.ui.common import create_ui
+from runepy.ui.layouts import EDITOR_TOOLBAR_LAYOUT
 
 
 class EditorToolbar:
@@ -15,47 +17,22 @@ class EditorToolbar:
     def __init__(self, base, editor) -> None:
         self.base = base
         self.editor = editor
-        if DirectFrame is object:
-            self.frame = None
-            return
-        self.frame = DirectFrame(
-            frameColor=(0, 0, 0, 0.7),
-            frameSize=(-1.3, 1.3, -0.05, 0.05),
-            pos=(0, 0, 0.95),
-        )
-        self.mode_menu = DirectOptionMenu(
-            parent=self.frame,
-            items=["Tile", "Interactable"],
-            scale=0.05,
-            initialitem=0,
-            command=self._set_mode,
-            pos=(-1.2, 0, 0),
-        )
-        DirectButton(
-            parent=self.frame,
-            text="Save",
-            scale=0.05,
-            pos=(0.2, 0, 0),
-            command=self.editor.save_map,
-        )
-        DirectButton(
-            parent=self.frame,
-            text="Texture",
-            scale=0.05,
-            pos=(0.5, 0, 0),
-            command=self.editor.open_texture_editor,
-        )
-        DirectButton(
-            parent=self.frame,
-            text="Load",
-            scale=0.05,
-            pos=(0.8, 0, 0),
-            command=self.editor.load_map,
-        )
+        layout = EDITOR_TOOLBAR_LAYOUT
+        self.frame, widgets = create_ui(layout, self)
+        self.mode_menu = widgets.get("mode_menu")
 
     # ------------------------------------------------------------------
     def _set_mode(self, choice: str) -> None:
         self.editor.set_mode(choice.lower())
+    def _save_map(self) -> None:
+        self.editor.save_map()
+
+    def _open_texture_editor(self) -> None:
+        self.editor.open_texture_editor()
+
+    def _load_map(self) -> None:
+        self.editor.load_map()
+
 
     def destroy(self) -> None:
         if self.frame is not None and hasattr(self.frame, "destroy"):

--- a/src/runepy/loading_screen.py
+++ b/src/runepy/loading_screen.py
@@ -1,4 +1,5 @@
-from direct.gui.DirectGui import DirectFrame, DirectLabel, DirectWaitBar
+from runepy.ui.common import create_ui
+from runepy.ui.layouts import LOADING_SCREEN_LAYOUT
 
 
 class LoadingScreen:
@@ -6,32 +7,10 @@ class LoadingScreen:
 
     def __init__(self, base):
         self.base = base
-        # Fullscreen black background frame
-        self.frame = DirectFrame(
-            frameColor=(0, 0, 0, 1), frameSize=(-1, 1, -1, 1)
-        )
-        # Central container mimicking RuneScape's red rectangle
-        self.container = DirectFrame(
-            parent=self.frame,
-            frameColor=(0.4, 0, 0, 1),
-            frameSize=(-0.7, 0.7, -0.15, 0.15),
-        )
-        self.label = DirectLabel(
-            text="Loading...",
-            parent=self.container,
-            pos=(0, 0, 0.05),
-            scale=0.07,
-            frameColor=(0, 0, 0, 0),
-        )
-        self.bar = DirectWaitBar(
-            parent=self.container,
-            pos=(0, 0, -0.05),
-            frameSize=(-0.6, 0.6, -0.05, 0.05),
-            frameColor=(0.2, 0, 0, 1),
-            barColor=(1, 0, 0, 1),
-            range=100,
-            value=0,
-        )
+        self.frame, widgets = create_ui(LOADING_SCREEN_LAYOUT)
+        self.container = widgets.get("container")
+        self.label = widgets.get("label")
+        self.bar = widgets.get("bar")
 
     def update(self, value, text=None):
         """Update the progress bar and optional text."""

--- a/src/runepy/options_menu.py
+++ b/src/runepy/options_menu.py
@@ -6,6 +6,8 @@ from direct.gui.DirectGui import (
 )
 from panda3d.core import TextNode
 from direct.showbase.DirectObject import DirectObject
+from runepy.ui.common import create_ui
+from runepy.ui.layouts import OPTIONS_MENU_LAYOUT
 
 
 class KeyBindingManager(DirectObject):
@@ -61,45 +63,17 @@ class OptionsMenu:
         if self.visible:
             return
         self.visible = True
-        self.frame = DirectFrame(
-            frameColor=(0, 0, 0, 0.7),
-            frameSize=(-0.7, 0.7, -0.6, 0.6),
-        )
+        layout = dict(OPTIONS_MENU_LAYOUT)
+        children = list(layout.get("children", []))
         y = 0.5
         self.entries = {}
         for action, key in self.manager.bindings.items():
-            DirectLabel(
-                text=action,
-                pos=(-0.6, 0, y),
-                scale=0.05,
-                parent=self.frame,
-                text_align=TextNode.ALeft,
-            )
-            entry = DirectEntry(
-                initialText=key,
-                pos=(0.0, 0, y),
-                scale=0.05,
-                width=10,
-                numLines=1,
-                focus=0,
-                parent=self.frame,
-            )
-            self.entries[action] = entry
+            children.append({"type": "label", "text": action, "pos": (-0.6, 0, y), "scale": 0.05, "text_align": TextNode.ALeft})
+            children.append({"type": "entry", "name": f"entry_{action}", "initialText": key, "pos": (0.0, 0, y), "scale": 0.05, "width": 10, "numLines": 1, "focus": 0})
             y -= 0.1
-        DirectButton(
-            text="Save",
-            command=self.apply,
-            pos=(-0.2, 0, -0.5),
-            scale=0.05,
-            parent=self.frame,
-        )
-        DirectButton(
-            text="Close",
-            command=self.close,
-            pos=(0.2, 0, -0.5),
-            scale=0.05,
-            parent=self.frame,
-        )
+        layout["children"] = children
+        self.frame, widgets = create_ui(layout, self)
+        self.entries = {a: widgets.get(f"entry_{a}") for a in self.manager.bindings}
 
     def apply(self):
         for action, entry in self.entries.items():

--- a/src/runepy/ui/builder.py
+++ b/src/runepy/ui/builder.py
@@ -10,6 +10,8 @@ try:
         DirectSlider,
         DirectLabel,
         DirectEntry,
+        DirectOptionMenu,
+        DirectWaitBar,
     )
 except Exception:  # pragma: no cover - Panda3D may be missing
     DirectFrame = None  # type: ignore
@@ -17,6 +19,8 @@ except Exception:  # pragma: no cover - Panda3D may be missing
     DirectSlider = None  # type: ignore
     DirectLabel = None  # type: ignore
     DirectEntry = None  # type: ignore
+    DirectOptionMenu = None  # type: ignore
+    DirectWaitBar = None  # type: ignore
 
 
 class StubWidget:
@@ -52,6 +56,8 @@ _WIDGETS = {
     "button": DirectButton or StubWidget,
     "slider": DirectSlider or StubWidget,
     "entry": DirectEntry or StubWidget,
+    "option_menu": DirectOptionMenu or StubWidget,
+    "wait_bar": DirectWaitBar or StubWidget,
 }
 
 
@@ -133,6 +139,12 @@ def build_ui(
             if cmd is not None:
                 params["command"] = cmd
             widget = _make_widget("button", parent_node, **params)
+        elif kind == "option_menu":
+            cmd_name = node.get("command")
+            cmd = (getattr(manager, cmd_name) if manager and cmd_name and hasattr(manager, cmd_name) else None)
+            if cmd is not None:
+                params["command"] = cmd
+            widget = _make_widget("option_menu", parent_node, **params)
         elif kind == "slider":
             label_text = node.get("label") or node.get("text")
             label_pos = node.get("label_pos")
@@ -171,6 +183,8 @@ def build_ui(
                 if value is not None:
                     params.setdefault("value", value)
                 widget = _make_widget("slider", parent_node, **params)
+        elif kind == "wait_bar":
+            widget = _make_widget("wait_bar", parent_node, **params)
         elif kind == "entry":
             widget = _make_widget("entry", parent_node, **params)
         elif kind == "label":

--- a/src/runepy/ui/common.py
+++ b/src/runepy/ui/common.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+"""Shared UI helpers."""
+
+from typing import Any, Dict
+
+from .builder import build_ui, StubWidget
+
+try:
+    from direct.gui.DirectGui import DirectFrame
+except Exception:  # pragma: no cover - Panda3D may be missing
+    DirectFrame = StubWidget  # type: ignore
+
+
+def create_ui(layout: Dict[str, Any], manager: Any | None = None, parent: Any | None = None):
+    """Return ``(frame, widgets)`` built from ``layout``."""
+    root = DirectFrame(parent=parent) if DirectFrame is not StubWidget else StubWidget()
+    widgets = build_ui(root, layout, manager)
+    return root, widgets
+
+__all__ = ["create_ui"]

--- a/src/runepy/ui/layouts.py
+++ b/src/runepy/ui/layouts.py
@@ -1,0 +1,157 @@
+"""Static UI layouts used by various components."""
+
+from __future__ import annotations
+
+OPTIONS_MENU_LAYOUT = {
+    "type": "frame",
+    "frameColor": (0, 0, 0, 0.7),
+    "frameSize": (-0.7, 0.7, -0.6, 0.6),
+    "children": [
+        {
+            "type": "button",
+            "name": "save_btn",
+            "text": "Save",
+            "command": "apply",
+            "pos": (-0.2, 0, -0.5),
+            "scale": 0.05,
+        },
+        {
+            "type": "button",
+            "name": "close_btn",
+            "text": "Close",
+            "command": "close",
+            "pos": (0.2, 0, -0.5),
+            "scale": 0.05,
+        },
+    ],
+}
+
+EDITOR_TOOLBAR_LAYOUT = {
+    "type": "frame",
+    "frameColor": (0, 0, 0, 0.7),
+    "frameSize": (-1.3, 1.3, -0.05, 0.05),
+    "pos": (0, 0, 0.95),
+    "children": [
+        {
+            "type": "option_menu",
+            "name": "mode_menu",
+            "items": ["Tile", "Interactable"],
+            "scale": 0.05,
+            "initialitem": 0,
+            "command": "_set_mode",
+            "pos": (-1.2, 0, 0),
+        },
+        {
+            "type": "button",
+            "name": "save_btn",
+            "text": "Save",
+            "command": "_save_map",
+            "scale": 0.05,
+            "pos": (0.2, 0, 0),
+        },
+        {
+            "type": "button",
+            "name": "texture_btn",
+            "text": "Texture",
+            "command": "_open_texture_editor",
+            "scale": 0.05,
+            "pos": (0.5, 0, 0),
+        },
+        {
+            "type": "button",
+            "name": "load_btn",
+            "text": "Load",
+            "command": "_load_map",
+            "scale": 0.05,
+            "pos": (0.8, 0, 0),
+        },
+    ],
+}
+
+# Build the texture editor layout with palette and grid buttons
+_palette_values = [0, 64, 128, 192, 255]
+_palette_step = 0.24
+_palette_children = [
+    {
+        "type": "button",
+        "name": f"palette_{i}",
+        "text": "",
+        "frameColor": (val / 255.0, val / 255.0, val / 255.0, 1),
+        "scale": 0.05,
+        "pos": (-0.55 + i * _palette_step, 0, 0.45),
+    }
+    for i, val in enumerate(_palette_values)
+]
+
+_grid_step = 0.07
+_grid_start = -0.5
+_grid_children = [
+    {
+        "type": "button",
+        "name": f"cell_{x}_{y}",
+        "text": "",
+        "scale": 0.03,
+        "pos": (_grid_start + x * _grid_step, 0, 0.35 - y * _grid_step),
+    }
+    for y in range(16)
+    for x in range(16)
+]
+
+TEXTURE_EDITOR_LAYOUT = {
+    "type": "frame",
+    "frameColor": (0, 0, 0, 1),
+    "frameSize": (-0.6, 0.6, -0.6, 0.6),
+    "pos": (0, 0, 0.2),
+    "children": _palette_children + _grid_children
+    + [
+        {
+            "type": "button",
+            "name": "close_btn",
+            "text": "Close",
+            "command": "close",
+            "scale": 0.05,
+            "pos": (0, 0, -0.55),
+        }
+    ],
+}
+
+LOADING_SCREEN_LAYOUT = {
+    "type": "frame",
+    "frameColor": (0, 0, 0, 1),
+    "frameSize": (-1, 1, -1, 1),
+    "children": [
+        {
+            "type": "frame",
+            "name": "container",
+            "frameColor": (0.4, 0, 0, 1),
+            "frameSize": (-0.7, 0.7, -0.15, 0.15),
+            "children": [
+                {
+                    "type": "label",
+                    "name": "label",
+                    "text": "Loading...",
+                    "pos": (0, 0, 0.05),
+                    "scale": 0.07,
+                    "frameColor": (0, 0, 0, 0),
+                },
+                {
+                    "type": "wait_bar",
+                    "name": "bar",
+                    "pos": (0, 0, -0.05),
+                    "frameSize": (-0.6, 0.6, -0.05, 0.05),
+                    "frameColor": (0.2, 0, 0, 1),
+                    "barColor": (1, 0, 0, 1),
+                    "range": 100,
+                    "value": 0,
+                },
+            ],
+        }
+    ],
+}
+
+__all__ = [
+    "OPTIONS_MENU_LAYOUT",
+    "EDITOR_TOOLBAR_LAYOUT",
+    "TEXTURE_EDITOR_LAYOUT",
+    "LOADING_SCREEN_LAYOUT",
+]

--- a/tests/test_editor_toolbar.py
+++ b/tests/test_editor_toolbar.py
@@ -8,15 +8,15 @@ class StubFrame:
         self.destroyed = True
 
 class StubMenu:
-    def __init__(self, parent=None, items=None, command=None, **kw):
-        self.items = items
-        self.command = command
+    def __init__(self, **kw):
+        self.command = kw.get('command')
         self.kw = kw
 
-class StubButton:
-    def __init__(self, parent=None, text='', command=None, **kw):
-        self.command = command
-        self.kw = kw
+
+def fake_create_ui(layout, manager=None, parent=None):
+    frame = StubFrame()
+    widgets = {'mode_menu': StubMenu(command=manager._set_mode)}
+    return frame, widgets
 
 class FakeEditor:
     def __init__(self):
@@ -37,10 +37,7 @@ class FakeBase:
 
 
 def test_toolbar_basic(monkeypatch):
-    monkeypatch.setattr('runepy.editor_toolbar.DirectFrame', StubFrame)
-    monkeypatch.setattr('runepy.editor_toolbar.DirectOptionMenu', StubMenu)
-    monkeypatch.setattr('runepy.editor_toolbar.DirectButton', StubButton)
-
+    monkeypatch.setattr('runepy.editor_toolbar.create_ui', fake_create_ui)
     editor = FakeEditor()
     tb = EditorToolbar(FakeBase(), editor)
     tb._set_mode('Interactable')


### PR DESCRIPTION
## Summary
- add `create_ui` helper for building widget trees
- store static UI layouts in `src/runepy/ui/layouts.py`
- update options menu, editor toolbar, texture editor and loading screen to use layouts
- extend builder with option menu and wait bar widgets
- simplify tests by patching `create_ui`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68894d48ae60832eb99b048c71b318ff