### PR TITLE
Refactor tile hover logic into shared helper

### DIFF
--- a/src/runepy/client.py
+++ b/src/runepy/client.py
@@ -4,7 +4,7 @@ try:
     import direct.showbase.ShowBaseGlobal as sbg
 except Exception:  # pragma: no cover - Panda3D may be missing
     sbg = None
-from runepy.utils import get_mouse_tile_coords, get_tile_from_mouse
+from runepy.utils import get_mouse_tile_coords, get_tile_from_mouse, update_tile_hover as util_update_tile_hover
 from direct.interval.IntervalGlobal import Sequence, Func
 import math
 import argparse
@@ -109,22 +109,13 @@ class Client(BaseApp):
             logger.debug(*args, **kwargs)
 
     def update_tile_hover(self, task):
-        mpos, tile_x, tile_y = get_mouse_tile_coords(
+        util_update_tile_hover(
             self.mouseWatcherNode,
             self.camera,
             self.render,
+            self.world,
+            debug=self.debug_info,
         )
-        if mpos:
-            self.debug_info.update_tile_info(mpos, tile_x, tile_y)
-            if (
-                -self.world.radius <= tile_x <= self.world.radius
-                and -self.world.radius <= tile_y <= self.world.radius
-            ):
-                self.world.highlight_tile(tile_x, tile_y)
-            else:
-                self.world.clear_highlight()
-        else:
-            self.world.clear_highlight()
         return task.cont
 
     def tile_click_event(self):

--- a/src/runepy/editor_window.py
+++ b/src/runepy/editor_window.py
@@ -7,7 +7,7 @@ from runepy.editor_toolbar import EditorToolbar
 from runepy.camera import FreeCameraControl
 from runepy.options_menu import KeyBindingManager, OptionsMenu
 from runepy.controls import Controls
-from runepy.utils import get_mouse_tile_coords
+from runepy.utils import update_tile_hover as util_update_tile_hover
 from runepy.debug import get_debug
 
 logger = logging.getLogger(__name__)
@@ -87,19 +87,9 @@ class EditorWindow(BaseApp):
         self.taskMgr.add(self.update_tile_hover, "updateTileHoverTask")
 
     def update_tile_hover(self, task):
-        mpos, tile_x, tile_y = get_mouse_tile_coords(
-            self.mouseWatcherNode, self.camera, self.render
+        util_update_tile_hover(
+            self.mouseWatcherNode, self.camera, self.render, self.world
         )
-        if mpos:
-            if (
-                -self.world.radius <= tile_x <= self.world.radius
-                and -self.world.radius <= tile_y <= self.world.radius
-            ):
-                self.world.highlight_tile(tile_x, tile_y)
-            else:
-                self.world.clear_highlight()
-        else:
-            self.world.clear_highlight()
         return task.cont
 
     def save_map(self):

--- a/src/runepy/utils.py
+++ b/src/runepy/utils.py
@@ -43,3 +43,30 @@ def get_tile_from_mouse(mouse_watcher: "MouseWatcher", camera, render):
     """Return just the tile coordinates from the mouse position."""
     _, tile_x, tile_y = get_mouse_tile_coords(mouse_watcher, camera, render)
     return tile_x, tile_y
+
+def update_tile_hover(
+    mouse_watcher: "MouseWatcher",
+    camera,
+    render,
+    world,
+    debug=None,
+) -> tuple:
+    """Highlight the tile under the mouse and optionally update debug info."""
+
+    mpos, tile_x, tile_y = get_mouse_tile_coords(mouse_watcher, camera, render)
+
+    if mpos:
+        if debug is not None:
+            debug.update_tile_info(mpos, tile_x, tile_y)
+
+        if (
+            -world.radius <= tile_x <= world.radius
+            and -world.radius <= tile_y <= world.radius
+        ):
+            world.highlight_tile(tile_x, tile_y)
+        else:
+            world.clear_highlight()
+    else:
+        world.clear_highlight()
+
+    return mpos, tile_x, tile_y


### PR DESCRIPTION
## Summary
- move tile hover code into `utils.update_tile_hover`
- use the helper in `Client` and `EditorWindow`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68895586c2ac832ea4fb9c0c87731d80