### PR TITLE
Support numpy grids in A* pathfinding

### DIFF
--- a/src/runepy/client.py
+++ b/src/runepy/client.py
@@ -167,7 +167,7 @@ class Client(BaseApp):
                 start_idx = (current_x - off_x, current_y - off_y)
                 end_idx = (snapped_x - off_x, snapped_y - off_y)
 
-                path = a_star(stitched.tolist(), start_idx, end_idx)
+                path = a_star(stitched, start_idx, end_idx)
                 self.log("Calculated Path:", path)
 
                 if path:


### PR DESCRIPTION
## Summary
- allow `a_star` to operate directly on numpy arrays
- simplify node representation to tuples and keep dataclass only for compatibility
- use numpy matrix directly in `Client.tile_click_event`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68895bbb2ca8832e999817bf3c125f15