### PR TITLE
Refactor debug manager base usage

### DIFF
--- a/src/runepy/debug/gui.py
+++ b/src/runepy/debug/gui.py
@@ -43,9 +43,8 @@ class DebugWindow(DirectFrame):
     def refresh_task(self, task: "Task"):
         if "stats" not in self.widgets:
             return task.again
-        try:
-            from direct.showbase.ShowBaseGlobal import base, render
-        except Exception:
+        base = getattr(self.manager, "base", None)
+        if base is None:
             return task.again
         world = getattr(base, "world", None)
         if world is not None:
@@ -53,7 +52,7 @@ class DebugWindow(DirectFrame):
             regions = len(rm.loaded)
         else:
             regions = 0
-        geoms = render.findAllMatches("**/+GeomNode").getNumPaths()
+        geoms = base.render.findAllMatches("**/+GeomNode").getNumPaths()
         self.widgets["stats"]["text"] = (
             f"Regions: {regions:2d}\nGeoms:   {geoms:3d}"
         )


### PR DESCRIPTION
## Summary
- track base instance in `NullDebugManager`
- avoid `ShowBaseGlobal` lookups in `DebugManager`
- update `DebugWindow.refresh_task` to use manager base

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68896117523c832eb955ebe2e027efcd