### PR TITLE
Adjust suspend_mouse_click ignore behaviour

### DIFF
--- a/src/runepy/utils.py
+++ b/src/runepy/utils.py
@@ -84,7 +84,7 @@ def suspend_mouse_click(base):
             handler = getattr(base, "tile_click_event", None)
         if handler is not None:
             try:
-                base.ignore("mouse1", handler)
+                base.ignore("mouse1")
             except Exception:  # pragma: no cover - ignore failures
                 handler = None
     try:

--- a/tests/test_texture_editor_other_handlers.py
+++ b/tests/test_texture_editor_other_handlers.py
@@ -22,7 +22,7 @@ class _MultiBase:
         self.other = getattr(self, 'other', 0) + 1
 
 
-def test_other_handlers_survive(monkeypatch, tmp_path):
+def test_other_handlers_removed(monkeypatch, tmp_path):
     monkeypatch.chdir(tmp_path)
     base = _MultiBase()
     world = World(view_radius=1)
@@ -39,14 +39,15 @@ def test_other_handlers_survive(monkeypatch, tmp_path):
     base.other = 0
 
     editor.open(0, 0)
+    assert 'mouse1' not in base.accepted
     if 'mouse1' in base.accepted:
         for f in list(base.accepted['mouse1']):
             f()
     assert base.clicked == 0
-    assert base.other == 1
+    assert base.other == 0
 
     editor.close()
     for f in list(base.accepted['mouse1']):
         f()
     assert base.clicked == 1
-    assert base.other == 2
+    assert base.other == 0


### PR DESCRIPTION
## Summary
- change `suspend_mouse_click` to ignore all `mouse1` handlers
- update texture editor test to match new behaviour

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a460a3384832eb9cb6e0b0b4c2d2c