### PR TITLE
Remove deprecated Node dataclass

### DIFF
--- a/src/runepy/pathfinding.py
+++ b/src/runepy/pathfinding.py
@@ -1,7 +1,6 @@
 # pathfinding.py
 
 import heapq
-from dataclasses import dataclass
 from typing import Iterable, Tuple, Union
 
 import logging
@@ -12,15 +11,6 @@ from direct.interval.IntervalGlobal import Sequence, Func
 import numpy as np
 
 logger = logging.getLogger(__name__)
-
-
-@dataclass(order=True)
-class Node:  # pragma: no cover - retained for API compatibility
-    position: tuple
-    parent: "Node" = None
-    g: float = 0
-    h: float = 0
-    f: float = 0
 
 
 def a_star(


### PR DESCRIPTION
## Summary
- drop the `Node` dataclass from `pathfinding`
- clean up the unused `dataclasses` import

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a475f34b0832eac814c5ab8a0f615