### PR TITLE
Add verbose logging option

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,2 +1,3 @@
 Add F1 Debug Window with live stats, actions, and variable tweaks
 Add data-driven debug window builder
+Add optional verbose logging via --verbose flag

--- a/README.md
+++ b/README.md
@@ -158,6 +158,8 @@ manager.update(70, 20)  # moves into the next region triggering load/unload
 
 Logging is configured automatically when the package is imported.
 Messages are written to `logs/runepy.log` with warnings in `logs/warnings.log` and errors in `logs/errors.log`.
+Passing `--verbose` to the command line entry point enables tracing of all
+function calls and writes them to `logs/verbose.log`.
 
 ## Utilities
 

--- a/src/runepy/__init__.py
+++ b/src/runepy/__init__.py
@@ -9,6 +9,7 @@ from .terrain import TerrainTile, FLAG_BLOCKED
 from .ui.manager import UIManager
 from .pathfinding import Pathfinder
 from .input_binder import InputBinder
+from . import verbose
 
 try:
     from .base_app import BaseApp
@@ -25,4 +26,5 @@ __all__ = [
     "UIManager",
     "Pathfinder",
     "InputBinder",
+    "verbose",
 ]

--- a/src/runepy/client.py
+++ b/src/runepy/client.py
@@ -6,6 +6,7 @@ except Exception:  # pragma: no cover - Panda3D may be missing
     sbg = None
 from runepy.utils import update_tile_hover as util_update_tile_hover
 import argparse
+from runepy import verbose
 
 logger = logging.getLogger(__name__)
 
@@ -150,7 +151,15 @@ def main(args=None):
         default="game",
         help="Start in regular game mode or map editor",
     )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Enable verbose logging of all function calls",
+    )
     parsed = parser.parse_args(args)
+
+    if parsed.verbose:
+        verbose.enable()
 
     if parsed.mode == "editor":
         from runepy.editor_window import EditorWindow

--- a/src/runepy/verbose.py
+++ b/src/runepy/verbose.py
@@ -1,0 +1,47 @@
+import logging
+import sys
+from types import FrameType
+from .logging_config import LOG_DIR
+
+logger = logging.getLogger("runepy.verbose")
+FORMAT = "%(asctime)s [%(levelname)s] %(name)s: %(message)s"
+_verbose_handler = logging.FileHandler(str(LOG_DIR / "verbose.log"))
+_verbose_handler.setLevel(logging.DEBUG)
+_verbose_handler.setFormatter(logging.Formatter(FORMAT))
+_enabled = False
+
+def _trace(frame: FrameType, event: str, arg):
+    if event in {"call", "return", "exception"}:
+        code = frame.f_code
+        name = f"{code.co_filename}:{code.co_name}:{frame.f_lineno}"
+        if event == "call":
+            logger.debug("CALL %s", name)
+        elif event == "return":
+            logger.debug("RETURN %s", name)
+        elif event == "exception":
+            exc_type, exc_val, _ = arg
+            logger.debug("EXCEPTION %s %s: %s", name, exc_type.__name__, exc_val)
+    return _trace
+
+
+def enable() -> None:
+    """Enable verbose tracing and log all function calls."""
+    global _enabled
+    if _enabled:
+        return
+    root = logging.getLogger()
+    root.setLevel(logging.DEBUG)
+    root.addHandler(_verbose_handler)
+    sys.settrace(_trace)
+    _enabled = True
+
+
+def disable() -> None:
+    """Disable verbose tracing."""
+    global _enabled
+    if not _enabled:
+        return
+    sys.settrace(None)
+    root = logging.getLogger()
+    root.removeHandler(_verbose_handler)
+    _enabled = False


### PR DESCRIPTION
## Summary
- add optional verbose logging trace
- expose verbose utilities from package
- add `--verbose` flag to CLI
- document verbose flag in README
- update changelog

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for numpy and panda3d)*

------
https://chatgpt.com/codex/tasks/task_e_688a50676b44832e90e841da1f3f2762