### PR TITLE
Fix verbose logging cleanup

### DIFF
--- a/src/runepy/verbose.py
+++ b/src/runepy/verbose.py
@@ -1,5 +1,6 @@
 import logging
 import sys
+import atexit
 from types import FrameType
 from .logging_config import LOG_DIR
 
@@ -15,12 +16,17 @@ def _trace(frame: FrameType, event: str, arg):
         code = frame.f_code
         name = f"{code.co_filename}:{code.co_name}:{frame.f_lineno}"
         if event == "call":
-            logger.debug("CALL %s", name)
+            if logger:
+                logger.debug("CALL %s", name)
         elif event == "return":
-            logger.debug("RETURN %s", name)
+            if logger:
+                logger.debug("RETURN %s", name)
         elif event == "exception":
             exc_type, exc_val, _ = arg
-            logger.debug("EXCEPTION %s %s: %s", name, exc_type.__name__, exc_val)
+            if logger:
+                logger.debug(
+                    "EXCEPTION %s %s: %s", name, exc_type.__name__, exc_val
+                )
     return _trace
 
 
@@ -33,6 +39,7 @@ def enable() -> None:
     root.setLevel(logging.DEBUG)
     root.addHandler(_verbose_handler)
     sys.settrace(_trace)
+    atexit.register(disable)
     _enabled = True
 
 

--- a/tests/test_verbose.py
+++ b/tests/test_verbose.py
@@ -1,0 +1,11 @@
+import sys
+from runepy.verbose import enable, disable
+
+
+def test_verbose_enable_disable():
+    enable()
+    try:
+        assert sys.gettrace() is not None
+    finally:
+        disable()
+    assert sys.gettrace() is None


### PR DESCRIPTION
## Summary
- prevent verbose tracing from raising an error during shutdown by
  cleaning up the handler with `atexit` and guarding logger usage
- test enabling and disabling verbose tracing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a56188354832e9d294bd515b584af