### PR TITLE
Improve log handler filtering

### DIFF
--- a/src/runepy/logging_config.py
+++ b/src/runepy/logging_config.py
@@ -7,13 +7,16 @@ LOG_DIR.mkdir(exist_ok=True)
 
 # Configure loggers
 FORMAT = "%(asctime)s [%(levelname)s] %(name)s: %(message)s"
-handlers = [
-    logging.FileHandler(str(LOG_DIR / "runepy.log")),
-    logging.FileHandler(str(LOG_DIR / "warnings.log")),
-]
+runepy_handler = logging.FileHandler(str(LOG_DIR / "runepy.log"))
+runepy_handler.setLevel(logging.INFO)
+
+warnings_handler = logging.FileHandler(str(LOG_DIR / "warnings.log"))
+warnings_handler.setLevel(logging.WARNING)
+
 error_handler = logging.FileHandler(str(LOG_DIR / "errors.log"))
 error_handler.setLevel(logging.ERROR)
-handlers.append(error_handler)
+
+handlers = [runepy_handler, warnings_handler, error_handler]
 
 logging.basicConfig(level=logging.INFO, format=FORMAT, handlers=handlers)
 logging.captureWarnings(True)

--- a/src/runepy/verbose.py
+++ b/src/runepy/verbose.py
@@ -51,4 +51,5 @@ def disable() -> None:
     sys.settrace(None)
     root = logging.getLogger()
     root.removeHandler(_verbose_handler)
+    root.setLevel(logging.INFO)
     _enabled = False


### PR DESCRIPTION
## Summary
- only log warnings and errors to their respective files
- keep verbose logs separate
- reset root level when disabling verbose logging

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a588cbe60832e86627de1a72040ba