### PR TITLE
Refine logging handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,9 +157,11 @@ manager.update(70, 20)  # moves into the next region triggering load/unload
 ## Logging
 
 Logging is configured automatically when the package is imported.
-Messages are written to `logs/runepy.log` with warnings in `logs/warnings.log` and errors in `logs/errors.log`.
+Messages are written to `logs/runepy.log` while warnings and errors are routed
+to `logs/warnings.log` and `logs/errors.log` respectively. Only records for the
+matching level are written to these warning and error files.
 Passing `--verbose` to the command line entry point enables tracing of all
-function calls and writes them to `logs/verbose.log`.
+function calls and writes them exclusively to `logs/verbose.log`.
 
 ## Utilities
 

--- a/src/runepy/logging_config.py
+++ b/src/runepy/logging_config.py
@@ -1,19 +1,36 @@
 import logging
 from pathlib import Path
+
 _ROOT_DIR = Path(__file__).resolve().parent.parent
 LOG_DIR = _ROOT_DIR / "logs"
 LOG_DIR.mkdir(exist_ok=True)
 
-
 # Configure loggers
 FORMAT = "%(asctime)s [%(levelname)s] %(name)s: %(message)s"
-handlers = [
-    logging.FileHandler(str(LOG_DIR / "runepy.log")),
-    logging.FileHandler(str(LOG_DIR / "warnings.log")),
-]
+
+
+class _ExactLevelFilter(logging.Filter):
+    """Filter that only passes records matching ``level`` exactly."""
+
+    def __init__(self, level: int) -> None:
+        super().__init__()
+        self.level = level
+
+    def filter(self, record: logging.LogRecord) -> bool:  # pragma: no cover - trivial
+        return record.levelno == self.level
+
+
+info_handler = logging.FileHandler(str(LOG_DIR / "runepy.log"))
+info_handler.setLevel(logging.INFO)
+
+warning_handler = logging.FileHandler(str(LOG_DIR / "warnings.log"))
+warning_handler.setLevel(logging.WARNING)
+warning_handler.addFilter(_ExactLevelFilter(logging.WARNING))
+
 error_handler = logging.FileHandler(str(LOG_DIR / "errors.log"))
 error_handler.setLevel(logging.ERROR)
-handlers.append(error_handler)
+
+handlers = [info_handler, warning_handler, error_handler]
 
 logging.basicConfig(level=logging.INFO, format=FORMAT, handlers=handlers)
 logging.captureWarnings(True)


### PR DESCRIPTION
## Summary
- filter warning & error logs by level and keep verbose calls separate
- clarify logging behavior in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a588cbe60832e86627de1a72040ba