### PR TITLE
Add UI editor toggle binding

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -3,6 +3,7 @@
     "open_menu": "escape",
     "save_map": "control-s",
     "load_map": "control-l",
+    "toggle_ui_editor": "control-e",
     "toggle_tile": "mouse3",
     "toggle_interactable": "i",
     "move_left": "a",

--- a/src/runepy/editor_window.py
+++ b/src/runepy/editor_window.py
@@ -6,6 +6,7 @@ from runepy.map_editor import MapEditor
 from runepy.editor_toolbar import EditorToolbar
 from runepy.camera import FreeCameraControl
 from runepy.options_menu import KeyBindingManager, OptionsMenu
+from runepy.ui.editor import UIEditorController
 from runepy.controls import Controls
 from runepy.utils import update_tile_hover as util_update_tile_hover
 from runepy.debug import get_debug
@@ -40,6 +41,7 @@ class EditorWindow(BaseApp):
             "open_menu": "escape",
             "save_map": "control-s",
             "load_map": "control-l",
+            "toggle_ui_editor": "control-e",
             "toggle_tile": "mouse3",
             "toggle_interactable": "i",
             "move_left": "a",
@@ -49,8 +51,12 @@ class EditorWindow(BaseApp):
         self.options_menu = OptionsMenu(self, self.key_manager)
 
         self.key_manager.bind("open_menu", self.options_menu.toggle)
+        self.key_manager.bind("toggle_ui_editor", self._toggle_ui_editor)
         self.editor.register_bindings(self.key_manager)
         self.toolbar = EditorToolbar(self, self.editor)
+        toolbar_frame = getattr(self.toolbar, "frame", None)
+        self.ui_editor = UIEditorController(toolbar_frame)
+        self._ui_editor_enabled = False
         # Store the bound click handler so the texture editor can reliably
         # remove it without depending on ephemeral bound method objects.
         self.tile_click_event_ref = self.editor.handle_click
@@ -99,6 +105,14 @@ class EditorWindow(BaseApp):
     def load_map(self):
         self.editor.load_map()
         logger.info("Map loaded from map.json")
+
+    # ------------------------------------------------------------------
+    def _toggle_ui_editor(self) -> None:
+        if self._ui_editor_enabled:
+            self.ui_editor.disable()
+        else:
+            self.ui_editor.enable()
+        self._ui_editor_enabled = not self._ui_editor_enabled
 
 
 if __name__ == "__main__":

--- a/tests/test_editor_window_ui_editor_toggle.py
+++ b/tests/test_editor_window_ui_editor_toggle.py
@@ -1,0 +1,69 @@
+import importlib.util
+from pathlib import Path
+
+_stubs_spec = importlib.util.spec_from_file_location(
+    "stubs", Path(__file__).parent / "test_editor_window_method_handler.py"
+)
+_stubs = importlib.util.module_from_spec(_stubs_spec)
+assert _stubs_spec and _stubs_spec.loader
+_stubs_spec.loader.exec_module(_stubs)
+
+_MethodBase = _stubs._MethodBase
+_FakeMapEditor = _stubs._FakeMapEditor
+_FakeCamera = _stubs._FakeCamera
+_FakeControls = _stubs._FakeControls
+_FakeKeyManager = _stubs._FakeKeyManager
+_FakeOptionsMenu = _stubs._FakeOptionsMenu
+_FakeToolbar = _stubs._FakeToolbar
+
+class FakeUIEditor:
+    def __init__(self, parent):
+        self.parent = parent
+        self.enabled = False
+        self.enabled_calls = 0
+        self.disabled_calls = 0
+    def enable(self):
+        self.enabled = True
+        self.enabled_calls += 1
+    def disable(self):
+        self.enabled = False
+        self.disabled_calls += 1
+
+class StoreKeyManager(_FakeKeyManager):
+    def __init__(self, *a, **k):
+        super().__init__(*a, **k)
+        self.bindings = {}
+    def bind(self, name, on_press, on_release=None):
+        self.bindings[name] = on_press
+
+class ToolbarWithFrame(_FakeToolbar):
+    def __init__(self, *a, **k):
+        super().__init__(*a, **k)
+        self.frame = object()
+
+
+def test_ui_editor_toggle(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr("runepy.base_app.BaseApp", _MethodBase)
+    monkeypatch.setattr("runepy.editor_window.BaseApp", _MethodBase)
+    monkeypatch.setattr("runepy.editor_window.MapEditor", _FakeMapEditor)
+    monkeypatch.setattr("runepy.editor_window.FreeCameraControl", _FakeCamera)
+    monkeypatch.setattr("runepy.editor_window.Controls", _FakeControls)
+    monkeypatch.setattr("runepy.editor_window.KeyBindingManager", StoreKeyManager)
+    monkeypatch.setattr("runepy.editor_window.OptionsMenu", _FakeOptionsMenu)
+    monkeypatch.setattr("runepy.editor_window.EditorToolbar", ToolbarWithFrame)
+    monkeypatch.setattr("runepy.editor_window.UIEditorController", FakeUIEditor)
+
+    from runepy.editor_window import EditorWindow
+
+    app = EditorWindow()
+    app.initialize()
+
+    assert isinstance(app.ui_editor, FakeUIEditor)
+    km = app.key_manager
+    assert "toggle_ui_editor" in km.bindings
+    toggle = km.bindings["toggle_ui_editor"]
+    toggle()
+    assert app.ui_editor.enabled
+    toggle()
+    assert not app.ui_editor.enabled


### PR DESCRIPTION
## Summary
- add `toggle_ui_editor` binding in config
- instantiate `UIEditorController` in `EditorWindow` and wire up toggle
- regression test for the new key binding

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a6c6fcde0832e867d1fe26641aef7