### PR TITLE
Add pre-commit configuration and documentation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,22 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.4.2
+    hooks:
+      - id: black
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.4.4
+    hooks:
+      - id: ruff
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.8.0
+    hooks:
+      - id: mypy
+  - repo: https://github.com/PyCQA/bandit
+    rev: 1.7.5
+    hooks:
+      - id: bandit
+        args: ["-r", "src"]
+  - repo: https://github.com/pre-commit/pyproject-toml
+    rev: v0.1.5
+    hooks:
+      - id: pyproject-toml-check

--- a/README.md
+++ b/README.md
@@ -177,6 +177,23 @@ function calls and writes them exclusively to `logs/verbose.log`.
 tile coordinates using the camera and render nodes. Pass the current camera and
 `render` root when calling these helpers.
 
+## Pre-commit hooks
+
+This project uses [pre-commit](https://pre-commit.com/) to run linters and
+other checks before each commit. Install the hooks after cloning the
+repository:
+
+```bash
+pip install pre-commit
+pre-commit install
+```
+
+Run the hooks against all files at any time with:
+
+```bash
+pre-commit run --all-files
+```
+
 ## Tests
 
 Install the Python dependencies listed in `requirements.txt` and run the


### PR DESCRIPTION
## Summary
- add `.pre-commit-config.yaml` with Black, Ruff, MyPy, Bandit and pyproject-toml-check hooks
- document how to install and run pre-commit hooks in README

## Testing
- `pre-commit run --files README.md .pre-commit-config.yaml` *(fails: prompts for GitHub credentials)*
- `pytest -q` *(fails: AssertionError in tests/test_map_editor.py::test_save_and_load_map and 5 errors in benchmarks)*

------
https://chatgpt.com/codex/tasks/task_e_689f513ebaac832eb68a1eb5d5d2ccd1