### PR TITLE
feat: clear region cache before loading map

### DIFF
--- a/src/runepy/map_editor.py
+++ b/src/runepy/map_editor.py
@@ -108,6 +108,7 @@ class MapEditor:
     def load_map(self):
         """Load map data by clearing and reloading regions from disk."""
         self.world.region_manager.loaded.clear()
+        self.world.region_manager.clear_cache()
         self.world.region_manager.ensure(0, 0)
 
     # ------------------------------------------------------------------

--- a/src/runepy/world/manager.py
+++ b/src/runepy/world/manager.py
@@ -30,6 +30,11 @@ class RegionManager(BaseRegionManager):
         if async_load:
             self._executor = ThreadPoolExecutor(max_workers=1)
 
+    
+    def clear_cache(self) -> None:
+        """Empty the region cache."""
+        self._cache.clear()
+
     # ------------------------------------------------------------------
     # Region helpers
     # ------------------------------------------------------------------

--- a/tests/test_region_manager.py
+++ b/tests/test_region_manager.py
@@ -24,3 +24,13 @@ def test_region_manager_loading(tmp_path, monkeypatch):
     assert (1, 1) in mgr.loaded
     assert len(mgr.loaded) <= 9
     assert (0, -1) not in mgr.loaded
+
+
+
+def test_clear_cache(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    mgr = RegionManager(view_radius=1)
+    mgr.ensure(0, 0)
+    assert mgr._cache
+    mgr.clear_cache()
+    assert mgr._cache == {}


### PR DESCRIPTION
## Summary
- add `clear_cache` to `RegionManager` to reset cached regions
- ensure `MapEditor.load_map` empties region cache before reloading
- test region cache clearing

## Testing
- `pytest -q`
- `pre-commit run --files src/runepy/world/manager.py src/runepy/map_editor.py tests/test_region_manager.py tests/test_map_editor.py` *(fails: Username for 'https://github.com')*

------
https://chatgpt.com/codex/tasks/task_e_689f574aff88832e909c9bcbb42447bb