### PR TITLE
Add pytest-benchmark dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Panda3D==1.10.15
 numpy==1.26.4
+pytest-benchmark==5.1.0


### PR DESCRIPTION
## Summary
- include pytest-benchmark in requirements to support benchmark tests

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f54a6cbec832eb449498545f885ec