### PR TITLE
Add linting, typing, and coverage configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,3 +30,23 @@ include = ["runepy*"]
 [tool.setuptools]
 py-modules = ["constants"]
 
+[tool.coverage.run]
+branch = true
+source = ["runepy"]
+
+[tool.coverage.report]
+fail_under = 85
+show_missing = true
+
+[tool.ruff]
+line-length = 88
+target-version = "py311"
+select = ["E", "F", "B", "I"]
+ignore = ["E501"]
+
+[tool.mypy]
+python_version = "3.11"
+disallow_untyped_defs = true
+ignore_missing_imports = true
+exclude = ["tests/"]
+


### PR DESCRIPTION
## Summary
- add coverage config enforcing 85% minimum coverage
- configure Ruff lint rules for Python 3.11
- configure Mypy type-checking for Python 3.11

## Testing
- `ruff check .`
- `mypy .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f5bb5fe50832ebf56cf7499bd20b9