### PR TITLE
Improve pathfinding heuristic and tests

### DIFF
--- a/src/runepy/pathfinding.py
+++ b/src/runepy/pathfinding.py
@@ -24,11 +24,14 @@ def a_star(
 
     ``grid`` may be a list-of-lists or :class:`numpy.ndarray` with ``1`` values
     indicating walkable tiles. ``start`` and ``end`` are grid coordinates using
-    ``(x, y)`` ordering starting at ``(0, 0)``.
+    ``(x, y)`` ordering starting at ``(0, 0)``. If no path exists, ``None`` is
+    returned.
     """
 
     def heuristic(a: Tuple[int, int], b: Tuple[int, int]) -> int:
-        return abs(a[0] - b[0]) + abs(a[1] - b[1])
+        dx = abs(a[0] - b[0])
+        dy = abs(a[1] - b[1])
+        return max(dx, dy)
 
     # Use numpy for fast indexing regardless of the initial grid type.
     grid = np.asarray(grid)

--- a/tests/test_pathfinding.py
+++ b/tests/test_pathfinding.py
@@ -64,3 +64,22 @@ def test_a_star_prefers_cheaper_diagonal():
     )
     assert path == [(0, 0), (1, 1), (2, 2)]
     assert (1, 0) not in path and (0, 1) not in path
+
+
+def test_a_star_no_path_exists():
+    grid = [
+        [1, 0],
+        [0, 1],
+    ]
+    path = pathfinding.a_star(grid, (0, 0), (1, 1))
+    assert path is None
+
+
+def test_a_star_diagonal_optimal_path():
+    grid = [
+        [1, 1, 1],
+        [1, 1, 1],
+        [1, 1, 1],
+    ]
+    path = pathfinding.a_star(grid, (0, 0), (2, 2))
+    assert path == [(0, 0), (1, 1), (2, 2)]


### PR DESCRIPTION
## Summary
- note that `a_star` may return `None` when no path is found
- switch `a_star` heuristic from Manhattan to Chebyshev distance for diagonal moves
- add tests for unreachable targets and optimal diagonal paths

## Testing
- `pytest tests/test_pathfinding.py`


------
https://chatgpt.com/codex/tasks/task_e_689f5e8d0d1c832e97fa051f9f125fa3