### PR TITLE
Enforce strict zip in pathfinding

### DIFF
--- a/src/runepy/pathfinding.py
+++ b/src/runepy/pathfinding.py
@@ -89,7 +89,7 @@ def a_star(
         walkable = tile_vals != 0
         nx, ny, step_costs = nx[walkable], ny[walkable], step_costs[walkable]
 
-        for nx_i, ny_i, step_cost in zip(nx, ny, step_costs):
+        for nx_i, ny_i, step_cost in zip(nx, ny, step_costs, strict=True):
             dx = int(nx_i - cx)
             dy = int(ny_i - cy)
             if dx and dy:


### PR DESCRIPTION
## Summary
- require equal-length neighbor arrays by enabling `strict=True` in pathfinding loop

## Testing
- `pytest tests/test_pathfinding.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3418fe018832e8adb552766d898e7