### PR TITLE
refactor: access layout directly

### DIFF
--- a/src/runepy/ui/manager.py
+++ b/src/runepy/ui/manager.py
@@ -34,7 +34,7 @@ class UIManager:
                 module = importlib.import_module(layout)
                 if not hasattr(module, "LAYOUT"):
                     raise ValueError(f"No LAYOUT in {layout}")
-                data = getattr(module, "LAYOUT")
+                data = module.LAYOUT
         else:
             data = layout
 


### PR DESCRIPTION
## Summary
- avoid getattr to access layout data with a direct attribute access

## Testing
- `ruff src/runepy/ui/manager.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a730cb32c0832ebda1871c7eef0e36