### PR TITLE
Remove unused size variable and expand region load test

### DIFF
--- a/tests/test_region_bin.py
+++ b/tests/test_region_bin.py
@@ -31,7 +31,6 @@ def test_region_load_v1(tmp_path, monkeypatch):
     path = MAPS_DIR / "region_0_0.bin"
     path.parent.mkdir(parents=True)
 
-    size = REGION_SIZE * REGION_SIZE
     height = np.zeros((REGION_SIZE, REGION_SIZE), dtype=np.int16)
     base = np.zeros((REGION_SIZE, REGION_SIZE), dtype=np.uint8)
     overlay = np.zeros((REGION_SIZE, REGION_SIZE), dtype=np.uint8)
@@ -46,5 +45,8 @@ def test_region_load_v1(tmp_path, monkeypatch):
 
     loaded = Region.load(0, 0)
     assert loaded.height[1, 1] == 1
+    assert np.array_equal(loaded.base, base)
+    assert np.array_equal(loaded.overlay, overlay)
+    assert np.array_equal(loaded.flags, flags)
     assert loaded.textures.shape == (REGION_SIZE, REGION_SIZE, 16, 16)
     assert np.all(loaded.textures == 0)


### PR DESCRIPTION
## Summary
- clean up region bin test by removing unused `size` variable
- verify base, overlay, and flag arrays when loading region files

## Testing
- `pytest tests/test_region_bin.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7320b73f4832e97eb128e33e8d4e3