### PR TITLE
chore: normalize EOF in world module

### DIFF
--- a/src/runepy/world/world.py
+++ b/src/runepy/world/world.py
@@ -232,5 +232,3 @@ class World:
     def shutdown(self) -> None:
         """Shut down the underlying :class:`RegionManager`."""
         self.region_manager.shutdown()
-
-


### PR DESCRIPTION
## Summary
- run `ruff check --fix` across project
- trim trailing blank line in `world.py`

## Testing
- `ruff check --fix src/runepy/world/world.py src/runepy/client.py src/runepy/debug/manager.py src/runepy/editor_window.py src/runepy/map_editor.py src/runepy/texture_editor.py src/runepy/world/region.py tests`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a7395e8868832ebdbb515df297d741