### PR TITLE
style: nest ruff lint configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,8 @@ show_missing = true
 [tool.ruff]
 line-length = 88
 target-version = "py311"
+
+[tool.ruff.lint]
 select = ["E", "F", "B", "I"]
 ignore = ["E501"]
 


### PR DESCRIPTION
## Summary
- move `select` and `ignore` keys into new `[tool.ruff.lint]` table

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a73dfb4e84832ea55d25e10b463648