### PR TITLE
Sort imports to satisfy ruff

### DIFF
--- a/src/runepy/texture_editor.py
+++ b/src/runepy/texture_editor.py
@@ -4,16 +4,17 @@ from __future__ import annotations
 
 from typing import Any
 
-from constants import REGION_SIZE
-from runepy.ui.common import create_ui
-from runepy.ui.layouts import TEXTURE_EDITOR_LAYOUT
-from runepy.world.region import local_tile, world_to_region
-
 try:
     from direct.gui.DirectGui import DirectButton, DirectFrame
 except Exception:  # pragma: no cover - Panda3D may be missing
     DirectFrame = object  # type: ignore
     DirectButton = object  # type: ignore
+
+from constants import REGION_SIZE
+from runepy.ui.common import create_ui
+from runepy.ui.layouts import TEXTURE_EDITOR_LAYOUT
+from runepy.world.region import local_tile, world_to_region
+
 
 class TextureEditor:
     """Lightweight tool for editing per-tile textures."""

--- a/src/runepy/world/region.py
+++ b/src/runepy/world/region.py
@@ -9,9 +9,6 @@ from typing import ClassVar, Dict, List, Tuple
 
 import numpy as np
 
-from constants import REGION_SIZE
-from runepy.paths import MAPS_DIR
-
 try:
     from panda3d.core import (
         Geom,
@@ -26,6 +23,9 @@ except Exception:  # pragma: no cover - Panda3D may be missing during tests
     Geom = GeomNode = GeomTriangles = None
     GeomVertexData = GeomVertexFormat = GeomVertexWriter = None
     NodePath = None
+
+from constants import REGION_SIZE
+from runepy.paths import MAPS_DIR
 
 logger = logging.getLogger(__name__)
 LOAD_TIMES: Dict[Tuple[int, int], List[float]] = defaultdict(list)

--- a/src/runepy/world/world.py
+++ b/src/runepy/world/world.py
@@ -6,6 +6,32 @@ from typing import Any, Dict, List, Tuple
 
 import numpy as np
 
+try:
+    import direct.showbase.ShowBaseGlobal as sbg
+    from panda3d.core import (
+        BitMask32,
+        CardMaker,
+        CollisionNode,
+        CollisionPlane,
+        Geom,
+        GeomNode,
+        GeomTriangles,
+        GeomVertexData,
+        GeomVertexFormat,
+        GeomVertexWriter,
+        LineSegs,
+        NodePath,
+        Plane,
+        Point3,
+        Vec3,
+    )
+except Exception:  # pragma: no cover - Panda3D may be missing during tests
+    BitMask32 = CardMaker = CollisionNode = CollisionPlane = Plane = None
+    Point3 = Vec3 = LineSegs = NodePath = None
+    Geom = GeomNode = GeomTriangles = None
+    GeomVertexData = GeomVertexFormat = GeomVertexWriter = None
+    sbg = None
+
 from constants import REGION_SIZE
 from runepy.terrain import FLAG_BLOCKED
 

--- a/tests/benchmarks/test_pathfinding_bench.py
+++ b/tests/benchmarks/test_pathfinding_bench.py
@@ -14,6 +14,7 @@ optimisation):
 
 import numpy as np
 import pytest
+
 from runepy.pathfinding import a_star
 
 pytest.importorskip("pytest_benchmark")

--- a/tests/benchmarks/test_region_streaming_bench.py
+++ b/tests/benchmarks/test_region_streaming_bench.py
@@ -6,6 +6,7 @@ previously loaded regions in memory.
 """
 
 import pytest
+
 from runepy.world.manager import RegionManager
 from runepy.world.region import Region
 


### PR DESCRIPTION
## Summary
- Organize imports in texture editor and world modules
- Clean up benchmark test imports

## Testing
- `ruff check`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a73f5277a8832e93d351d8e4954c2a